### PR TITLE
Fix tap to focus, which never really worked

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.java
@@ -48,6 +48,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceView;
 import android.view.TextureView;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -78,1076 +79,1112 @@ import java.util.concurrent.Semaphore;
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class Camera2ApiManager extends CameraDevice.StateCallback {
 
-  private final String TAG = "Camera2ApiManager";
+    private final String TAG = "Camera2ApiManager";
 
-  private CameraDevice cameraDevice;
-  private SurfaceView surfaceView;
-  private TextureView textureView;
-  private Surface surfaceEncoder; //input surfaceEncoder from videoEncoder
-  private final CameraManager cameraManager;
-  private Handler cameraHandler;
-  private CameraCaptureSession cameraCaptureSession;
-  private boolean prepared = false;
-  private String cameraId = null;
-  private CameraHelper.Facing facing = Facing.BACK;
-  private CaptureRequest.Builder builderInputSurface;
-  private float fingerSpacing = 0;
-  private float zoomLevel = 0f;
-  private boolean lanternEnable = false;
-  private boolean videoStabilizationEnable = false;
-  private boolean opticalVideoStabilizationEnable = false;
-  private boolean autoFocusEnabled = true;
-  private boolean running = false;
-  private int fps = 30;
-  private final Semaphore semaphore = new Semaphore(0);
-  private CameraCallbacks cameraCallbacks;
+    private CameraDevice cameraDevice;
+    private SurfaceView surfaceView;
+    private TextureView textureView;
+    private Surface surfaceEncoder; //input surfaceEncoder from videoEncoder
+    private final CameraManager cameraManager;
+    private Handler cameraHandler;
+    private CameraCaptureSession cameraCaptureSession;
+    private boolean prepared = false;
+    private String cameraId = null;
+    private CameraHelper.Facing facing = Facing.BACK;
+    private CaptureRequest.Builder builderInputSurface;
+    private float fingerSpacing = 0;
+    private float zoomLevel = 0f;
+    private boolean lanternEnable = false;
+    private boolean videoStabilizationEnable = false;
+    private boolean opticalVideoStabilizationEnable = false;
+    private boolean autoFocusEnabled = true;
+    private boolean running = false;
+    private int fps = 30;
+    private final Semaphore semaphore = new Semaphore(0);
+    private CameraCallbacks cameraCallbacks;
 
-  public interface ImageCallback {
-    void onImageAvailable(Image image);
-  }
+    public interface ImageCallback {
+        void onImageAvailable(Image image);
+    }
 
-  private int sensorOrientation = 0;
-  private Rect faceSensorScale;
-  private FaceDetectorCallback faceDetectorCallback;
-  private boolean faceDetectionEnabled = false;
-  private int faceDetectionMode;
-  private ImageReader imageReader;
+    private int sensorOrientation = 0;
+    private Rect faceSensorScale;
+    private FaceDetectorCallback faceDetectorCallback;
+    private boolean faceDetectionEnabled = false;
+    private int faceDetectionMode;
+    private ImageReader imageReader;
 
-  public Camera2ApiManager(Context context) {
-    cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
-  }
+    public Camera2ApiManager(Context context) {
+        cameraManager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+    }
 
-  public void prepareCamera(SurfaceView surfaceView, Surface surface, int fps) {
-    this.surfaceView = surfaceView;
-    this.surfaceEncoder = surface;
-    this.fps = fps;
-    prepared = true;
-  }
+    public void prepareCamera(SurfaceView surfaceView, Surface surface, int fps) {
+        this.surfaceView = surfaceView;
+        this.surfaceEncoder = surface;
+        this.fps = fps;
+        prepared = true;
+    }
 
-  public void prepareCamera(TextureView textureView, Surface surface, int fps) {
-    this.textureView = textureView;
-    this.surfaceEncoder = surface;
-    this.fps = fps;
-    prepared = true;
-  }
+    public void prepareCamera(TextureView textureView, Surface surface, int fps) {
+        this.textureView = textureView;
+        this.surfaceEncoder = surface;
+        this.fps = fps;
+        prepared = true;
+    }
 
-  public void prepareCamera(Surface surface, int fps) {
-    this.surfaceEncoder = surface;
-    this.fps = fps;
-    prepared = true;
-  }
+    public void prepareCamera(Surface surface, int fps) {
+        this.surfaceEncoder = surface;
+        this.fps = fps;
+        prepared = true;
+    }
 
-  public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps) {
-    Size optimalResolution = Camera2ResolutionCalculator.INSTANCE.getOptimalResolution(new Size(width, height), getCameraResolutions(facing));
-    Log.i(TAG, "optimal resolution set to: " + optimalResolution.getWidth() + "x" + optimalResolution.getHeight());
-    surfaceTexture.setDefaultBufferSize(optimalResolution.getWidth(), optimalResolution.getHeight());
-    this.surfaceEncoder = new Surface(surfaceTexture);
-    this.fps = fps;
-    prepared = true;
-  }
+    public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps) {
+        Size optimalResolution = Camera2ResolutionCalculator.INSTANCE.getOptimalResolution(new Size(width, height), getCameraResolutions(facing));
+        Log.i(TAG, "optimal resolution set to: " + optimalResolution.getWidth() + "x" + optimalResolution.getHeight());
+        surfaceTexture.setDefaultBufferSize(optimalResolution.getWidth(), optimalResolution.getHeight());
+        this.surfaceEncoder = new Surface(surfaceTexture);
+        this.fps = fps;
+        prepared = true;
+    }
 
-  public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps, Facing facing) {
-    this.facing = facing;
-    prepareCamera(surfaceTexture, width, height, fps);
-  }
+    public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps, Facing facing) {
+        this.facing = facing;
+        prepareCamera(surfaceTexture, width, height, fps);
+    }
 
-  public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps, String cameraId) {
-    this.facing = getFacingByCameraId(cameraManager, cameraId);
-    prepareCamera(surfaceTexture, width, height, fps);
-  }
+    public void prepareCamera(SurfaceTexture surfaceTexture, int width, int height, int fps, String cameraId) {
+        this.facing = getFacingByCameraId(cameraManager, cameraId);
+        prepareCamera(surfaceTexture, width, height, fps);
+    }
 
-  public boolean isPrepared() {
-    return prepared;
-  }
+    public boolean isPrepared() {
+        return prepared;
+    }
 
-  private void startPreview(CameraDevice cameraDevice) {
-    try {
-      final List<Surface> listSurfaces = new ArrayList<>();
-      Surface preview = addPreviewSurface();
-      if (preview != null) listSurfaces.add(preview);
-      if (surfaceEncoder != preview && surfaceEncoder != null) listSurfaces.add(surfaceEncoder);
-      if (imageReader != null) listSurfaces.add(imageReader.getSurface());
-      cameraDevice.createCaptureSession(listSurfaces, new CameraCaptureSession.StateCallback() {
-        @Override
-        public void onConfigured(@NonNull CameraCaptureSession cameraCaptureSession) {
-          Camera2ApiManager.this.cameraCaptureSession = cameraCaptureSession;
-          try {
-            CaptureRequest captureRequest = drawSurface(listSurfaces);
-            if (captureRequest != null) {
-              cameraCaptureSession.setRepeatingRequest(captureRequest,
-                  faceDetectionEnabled ? cb : null, cameraHandler);
-              Log.i(TAG, "Camera configured");
-            } else {
-              Log.e(TAG, "Error, captureRequest is null");
+    private void startPreview(CameraDevice cameraDevice) {
+        try {
+            final List<Surface> listSurfaces = new ArrayList<>();
+            Surface preview = addPreviewSurface();
+            if (preview != null) listSurfaces.add(preview);
+            if (surfaceEncoder != preview && surfaceEncoder != null)
+                listSurfaces.add(surfaceEncoder);
+            if (imageReader != null) listSurfaces.add(imageReader.getSurface());
+            cameraDevice.createCaptureSession(listSurfaces, new CameraCaptureSession.StateCallback() {
+                @Override
+                public void onConfigured(@NonNull CameraCaptureSession cameraCaptureSession) {
+                    Camera2ApiManager.this.cameraCaptureSession = cameraCaptureSession;
+                    try {
+                        CaptureRequest captureRequest = drawSurface(listSurfaces);
+                        if (captureRequest != null) {
+                            cameraCaptureSession.setRepeatingRequest(captureRequest,
+                                    faceDetectionEnabled ? cb : null, cameraHandler);
+                            Log.i(TAG, "Camera configured");
+                        } else {
+                            Log.e(TAG, "Error, captureRequest is null");
+                        }
+                    } catch (CameraAccessException | NullPointerException e) {
+                        Log.e(TAG, "Error", e);
+                    } catch (IllegalStateException e) {
+                        reOpenCamera(cameraId != null ? cameraId : "0");
+                    }
+                }
+
+                @Override
+                public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
+                    cameraCaptureSession.close();
+                    if (cameraCallbacks != null)
+                        cameraCallbacks.onCameraError("Configuration failed");
+                    Log.e(TAG, "Configuration failed");
+                }
+            }, cameraHandler);
+        } catch (CameraAccessException | IllegalArgumentException e) {
+            if (cameraCallbacks != null) {
+                cameraCallbacks.onCameraError("Create capture session failed: " + e.getMessage());
             }
-          } catch (CameraAccessException | NullPointerException e) {
             Log.e(TAG, "Error", e);
-          } catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             reOpenCamera(cameraId != null ? cameraId : "0");
-          }
         }
+    }
 
-        @Override
-        public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
-          cameraCaptureSession.close();
-          if (cameraCallbacks != null) cameraCallbacks.onCameraError("Configuration failed");
-          Log.e(TAG, "Configuration failed");
+    private Surface addPreviewSurface() {
+        Surface surface = null;
+        if (surfaceView != null) {
+            surface = surfaceView.getHolder().getSurface();
+        } else if (textureView != null) {
+            final SurfaceTexture texture = textureView.getSurfaceTexture();
+            surface = new Surface(texture);
         }
-      }, cameraHandler);
-    } catch (CameraAccessException | IllegalArgumentException e) {
-      if (cameraCallbacks != null) {
-        cameraCallbacks.onCameraError("Create capture session failed: " + e.getMessage());
-      }
-      Log.e(TAG, "Error", e);
-    } catch (IllegalStateException e) {
-      reOpenCamera(cameraId != null ? cameraId : "0");
-    }
-  }
-
-  private Surface addPreviewSurface() {
-    Surface surface = null;
-    if (surfaceView != null) {
-      surface = surfaceView.getHolder().getSurface();
-    } else if (textureView != null) {
-      final SurfaceTexture texture = textureView.getSurfaceTexture();
-      surface = new Surface(texture);
-    }
-    return surface;
-  }
-
-  private CaptureRequest drawSurface(List<Surface> surfaces) {
-    try {
-      builderInputSurface = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
-      for (Surface surface : surfaces) if (surface != null) builderInputSurface.addTarget(surface);
-      setModeAuto(builderInputSurface);
-      adaptFpsRange(fps, builderInputSurface);
-      return builderInputSurface.build();
-    } catch (CameraAccessException | IllegalStateException e) {
-      Log.e(TAG, "Error", e);
-      return null;
-    }
-  }
-
-  private void setModeAuto(CaptureRequest.Builder builderInputSurface) {
-    try {
-      builderInputSurface.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
-    } catch (Exception ignored) { }
-  }
-
-  private void adaptFpsRange(int expectedFps, CaptureRequest.Builder builderInputSurface) {
-    List<Range<Integer>> fpsRanges = getSupportedFps(null, Facing.BACK);
-    if (fpsRanges != null && fpsRanges.size() > 0) {
-      Range<Integer> closestRange = fpsRanges.get(0);
-      int measure = Math.abs(closestRange.getLower() - expectedFps) + Math.abs(
-          closestRange.getUpper() - expectedFps);
-      for (Range<Integer> range : fpsRanges) {
-        if (CameraHelper.discardCamera2Fps(range, facing)) continue;
-        if (range.getLower() <= expectedFps && range.getUpper() >= expectedFps) {
-          int curMeasure = Math.abs(((range.getLower() + range.getUpper()) / 2) - expectedFps);
-          if (curMeasure < measure) {
-            closestRange = range;
-            measure = curMeasure;
-          } else if (curMeasure == measure) {
-            if (Math.abs(range.getUpper() - expectedFps) < Math.abs(closestRange.getUpper() - expectedFps)) {
-              closestRange = range;
-              measure = curMeasure;
-            }
-          }
-        }
-      }
-      Log.i(TAG, "fps: " + closestRange.getLower() + " - " + closestRange.getUpper());
-      builderInputSurface.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, closestRange);
-    }
-  }
-
-  public List<Range<Integer>> getSupportedFps(Size size, Facing facing) {
-    try {
-      CameraCharacteristics characteristics = null;
-      try {
-        characteristics = getCharacteristicsForFacing(cameraManager, facing);
-      } catch (CameraAccessException ignored) { }
-      if (characteristics == null) return null;
-      Range<Integer>[] fpsSupported = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
-      if (size != null) {
-        StreamConfigurationMap streamConfigurationMap =
-            characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-        List<Range<Integer>> list = new ArrayList<>();
-        long fd = streamConfigurationMap.getOutputMinFrameDuration(SurfaceTexture.class, size);
-        int maxFPS = (int)(10f / Float.parseFloat("0." + fd));
-        for (Range<Integer> r : fpsSupported) {
-          if (r.getUpper() <= maxFPS) {
-            list.add(r);
-          }
-        }
-        return list;
-      } else {
-        return Arrays.asList(fpsSupported);
-      }
-    } catch (IllegalStateException e) {
-      Log.e(TAG, "Error", e);
-      return null;
-    }
-  }
-
-  public int getLevelSupported() {
-    try {
-      CameraCharacteristics characteristics = getCameraCharacteristics();
-      if (characteristics == null) return -1;
-      Integer level = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
-      if (level == null) return -1;
-      return level;
-    } catch (IllegalStateException e) {
-      Log.e(TAG, "Error", e);
-      return -1;
-    }
-  }
-
-  public void openCamera() {
-    openCameraBack();
-  }
-
-  public void openCameraBack() {
-    openCameraFacing(Facing.BACK);
-  }
-
-  public void openCameraFront() {
-    openCameraFacing(Facing.FRONT);
-  }
-
-  public void openLastCamera() {
-    if (cameraId == null) {
-      openCameraBack();
-    } else {
-      openCameraId(cameraId);
-    }
-  }
-
-  public void setCameraFacing(CameraHelper.Facing cameraFacing) {
-    try {
-      String cameraId = getCameraIdForFacing(cameraManager, cameraFacing);
-      if (cameraId != null) {
-        facing = cameraFacing;
-        this.cameraId = cameraId;
-      }
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
-    }
-  }
-
-  public void setCameraId(String cameraId) {
-    this.cameraId = cameraId;
-  }
-
-  public CameraHelper.Facing getCameraFacing() {
-    return facing;
-  }
-
-  public Size[] getCameraResolutionsBack() {
-    return getCameraResolutions(Facing.BACK);
-  }
-
-  public Size[] getCameraResolutionsFront() {
-    return getCameraResolutions(Facing.FRONT);
-  }
-
-  public Size[] getCameraResolutions(Facing facing) {
-    try {
-      CameraCharacteristics characteristics = getCharacteristicsForFacing(cameraManager, facing);
-      if (characteristics == null) {
-        return new Size[0];
-      }
-
-      StreamConfigurationMap streamConfigurationMap =
-          characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-      if (streamConfigurationMap == null) return new Size[0];
-      Size[] outputSizes = streamConfigurationMap.getOutputSizes(SurfaceTexture.class);
-      return outputSizes != null ? outputSizes : new Size[0];
-    } catch (CameraAccessException | NullPointerException e) {
-      Log.e(TAG, "Error", e);
-      return new Size[0];
-    }
-  }
-
-  public Size[] getCameraResolutions(String cameraId) {
-    try {
-      CameraCharacteristics characteristics = getCharacteristicsForId(cameraManager, cameraId);
-      if (characteristics == null) {
-        return new Size[0];
-      }
-
-      StreamConfigurationMap streamConfigurationMap =
-          characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-      if (streamConfigurationMap == null) return new Size[0];
-      Size[] outputSizes = streamConfigurationMap.getOutputSizes(SurfaceTexture.class);
-      return outputSizes != null ? outputSizes : new Size[0];
-    } catch (CameraAccessException | NullPointerException e) {
-      Log.e(TAG, "Error", e);
-      return new Size[0];
-    }
-  }
-
-  @Nullable
-  public CameraCharacteristics getCameraCharacteristics() {
-    try {
-      return cameraId != null ? cameraManager.getCameraCharacteristics(cameraId) : null;
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
-      return null;
-    }
-  }
-
-  public boolean enableVideoStabilization() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return false;
-    int[] modes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES);
-    List<Integer> videoStabilizationList = new ArrayList<>();
-    for (int vsMode : modes) {
-      videoStabilizationList.add(vsMode);
-    }
-    if (!videoStabilizationList.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
-      Log.e(TAG, "video stabilization unsupported");
-      return false;
+        return surface;
     }
 
-    if (builderInputSurface != null) {
-      builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,
-          CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON);
-      videoStabilizationEnable = true;
-    }
-    return videoStabilizationEnable;
-  }
-
-  public void disableVideoStabilization() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    int[] modes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES);
-    List<Integer> videoStabilizationList = new ArrayList<>();
-    for (int vsMode : modes) {
-      videoStabilizationList.add(vsMode);
-    }
-    if (!videoStabilizationList.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
-      Log.e(TAG, "video stabilization unsupported");
-      return;
-    }
-    if (builderInputSurface != null) {
-      builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,
-          CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_OFF);
-      videoStabilizationEnable = false;
-    }
-  }
-
-  public boolean isVideoStabilizationEnabled() {
-    return videoStabilizationEnable;
-  }
-
-  public boolean enableOpticalVideoStabilization() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return false;
-
-    int[] opticalStabilizationModes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION);
-    List<Integer> opticalStabilizationList = new ArrayList<>();
-    for (int vsMode : opticalStabilizationModes) {
-      opticalStabilizationList.add(vsMode);
-    }
-
-    if (!opticalStabilizationList.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) {
-      Log.e(TAG, "OIS video stabilization unsupported");
-      return false;
-    }
-    if (builderInputSurface != null) {
-      builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE,
-              CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON);
-      opticalVideoStabilizationEnable = true;
-    }
-    return opticalVideoStabilizationEnable;
-  }
-
-  public void disableOpticalVideoStabilization() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    int[] modes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION);
-    List<Integer> videoStabilizationList = new ArrayList<>();
-    for (int vsMode : modes) {
-      videoStabilizationList.add(vsMode);
-    }
-    if (!videoStabilizationList.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) {
-      Log.e(TAG, "OIS video stabilization unsupported");
-      return;
-    }
-    if (builderInputSurface != null) {
-      builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE,
-              CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_OFF);
-      opticalVideoStabilizationEnable = false;
-    }
-  }
-
-  public boolean isOpticalStabilizationEnabled() {
-    return opticalVideoStabilizationEnable;
-  }
-
-  public void setFocusDistance(float distance) {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    if (builderInputSurface != null) {
-      try {
-        if (distance < 0) distance = 0f; //avoid invalid value
-        builderInputSurface.set(CaptureRequest.LENS_FOCUS_DISTANCE, distance);
-        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-            faceDetectionEnabled ? cb : null, null);
-      } catch (Exception e) {
-        Log.e(TAG, "Error", e);
-      }
-    }
-  }
-
-  public void setExposure(int value) {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    Range<Integer> supportedExposure =
-        characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
-    if (supportedExposure != null && builderInputSurface != null) {
-      if (value > supportedExposure.getUpper()) value = supportedExposure.getUpper();
-      if (value < supportedExposure.getLower()) value = supportedExposure.getLower();
-      try {
-        builderInputSurface.set(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, value);
-        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-            faceDetectionEnabled ? cb : null, null);
-      } catch (Exception e) {
-        Log.e(TAG, "Error", e);
-      }
-    }
-  }
-
-  public int getExposure() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return 0;
-    if (builderInputSurface != null) {
-      try {
-        return builderInputSurface.get(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION);
-      } catch (Exception e) {
-        Log.e(TAG, "Error", e);
-      }
-    }
-    return 0;
-  }
-
-
-
-  public int getMaxExposure() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return 0;
-    Range<Integer> supportedExposure =
-        characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
-    if (supportedExposure != null) {
-      return supportedExposure.getUpper();
-    }
-    return 0;
-  }
-
-  public int getMinExposure() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return 0;
-    Range<Integer> supportedExposure =
-        characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
-    if (supportedExposure != null) {
-      return supportedExposure.getLower();
-    }
-    return 0;
-  }
-
-  public void tapToFocus(MotionEvent event) {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    int pointerId = event.getPointerId(0);
-    int pointerIndex = event.findPointerIndex(pointerId);
-    // Get the pointer's current position
-    float x = event.getX(pointerIndex);
-    float y = event.getY(pointerIndex);
-    if (x < 100 || y < 100) return;
-
-    Rect touchRect = new Rect((int) (x - 100), (int) (y - 100),
-        (int) (x + 100), (int) (y + 100));
-    MeteringRectangle focusArea = new MeteringRectangle(touchRect, MeteringRectangle.METERING_WEIGHT_DONT_CARE);
-    if (builderInputSurface != null) {
-      try {
-        //cancel any existing AF trigger (repeated touches, etc.)
-        builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-        builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-            faceDetectionEnabled ? cb : null, null);
-        builderInputSurface.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{focusArea});
-        builderInputSurface.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
-        builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
-        builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_START);
-        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-            faceDetectionEnabled ? cb : null, null);
-      } catch (Exception e) {
-        Log.e(TAG, "Error", e);
-      }
-    }
-  }
-
-  /**
-   * Select camera facing
-   *
-   * @param selectedCameraFacing - CameraCharacteristics.LENS_FACING_FRONT,
-   * CameraCharacteristics.LENS_FACING_BACK,
-   * CameraCharacteristics.LENS_FACING_EXTERNAL
-   */
-  public void openCameraFacing(Facing selectedCameraFacing) {
-    try {
-      String cameraId = getCameraIdForFacing(cameraManager, selectedCameraFacing);
-      if (cameraId != null) {
-        openCameraId(cameraId);
-      } else {
-        Log.e(TAG, "Camera not supported"); // TODO maybe we want to throw some exception here?
-      }
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
-    }
-  }
-
-  public boolean isLanternSupported() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return false;
-    Boolean available = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
-    if (available == null) return false;
-    return available;
-  }
-
-  public boolean isLanternEnabled() {
-    return lanternEnable;
-  }
-
-  /**
-   * @required: <uses-permission android:name="android.permission.FLASHLIGHT"/>
-   */
-  public void enableLantern() throws Exception {
-    if (isLanternSupported()) {
-      if (builderInputSurface != null) {
+    private CaptureRequest drawSurface(List<Surface> surfaces) {
         try {
-          builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_TORCH);
-          cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-              faceDetectionEnabled ? cb : null, null);
-          lanternEnable = true;
-        } catch (Exception e) {
-          Log.e(TAG, "Error", e);
-        }
-      }
-    } else {
-      Log.e(TAG, "Lantern unsupported");
-      throw new Exception("Lantern unsupported");
-    }
-  }
-
-  /**
-   * @required: <uses-permission android:name="android.permission.FLASHLIGHT"/>
-   */
-  public void disableLantern() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    Boolean available = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
-    if (available == null) return;
-    if (available) {
-      if (builderInputSurface != null) {
-        try {
-          builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_OFF);
-          cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-              faceDetectionEnabled ? cb : null, null);
-          lanternEnable = false;
-        } catch (Exception e) {
-          Log.e(TAG, "Error", e);
-        }
-      }
-    }
-  }
-
-  public void enableAutoFocus() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    int[] supportedFocusModes =
-        characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
-    if (supportedFocusModes != null) {
-      List<Integer> focusModesList = new ArrayList<>();
-      for (int i : supportedFocusModes) focusModesList.add(i);
-      if (builderInputSurface != null) {
-        try {
-          if (!focusModesList.isEmpty()) {
-            //cancel any existing AF trigger
-            builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
-            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-                faceDetectionEnabled ? cb : null, null);
-            if (focusModesList.contains(CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)) {
-              builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
-                  CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
-              cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-                  faceDetectionEnabled ? cb : null, null);
-              autoFocusEnabled = true;
-            } else if (focusModesList.contains(CaptureRequest.CONTROL_AF_MODE_AUTO)) {
-              builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
-                  CaptureRequest.CONTROL_AF_MODE_AUTO);
-              cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-                  faceDetectionEnabled ? cb : null, null);
-              autoFocusEnabled = true;
-            } else {
-              builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, focusModesList.get(0));
-              cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-                  faceDetectionEnabled ? cb : null, null);
-              autoFocusEnabled = false;
-            }
-          }
-        } catch (Exception e) {
-          Log.e(TAG, "Error", e);
-        }
-      }
-    }
-  }
-
-  public void disableAutoFocus() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    int[] supportedFocusModes =
-        characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
-    if (supportedFocusModes != null) {
-      if (builderInputSurface != null) {
-        for (int mode : supportedFocusModes) {
-          try {
-            if (mode == CaptureRequest.CONTROL_AF_MODE_OFF) {
-              builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
-                  CaptureRequest.CONTROL_AF_MODE_OFF);
-              cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-                  faceDetectionEnabled ? cb : null, null);
-              autoFocusEnabled = false;
-              return;
-            }
-          } catch (Exception e) {
+            builderInputSurface = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+            for (Surface surface : surfaces)
+                if (surface != null) builderInputSurface.addTarget(surface);
+            setModeAuto(builderInputSurface);
+            adaptFpsRange(fps, builderInputSurface);
+            return builderInputSurface.build();
+        } catch (CameraAccessException | IllegalStateException e) {
             Log.e(TAG, "Error", e);
-          }
+            return null;
         }
-      }
     }
-  }
 
-  public boolean isAutoFocusEnabled() {
-    return autoFocusEnabled;
-  }
-
-  public boolean enableFaceDetection(FaceDetectorCallback faceDetectorCallback) {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) {
-      Log.e(TAG, "face detection called with camera stopped");
-      return false;
-    }
-    faceSensorScale = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
-    sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
-    int[] fd = characteristics.get(CameraCharacteristics.STATISTICS_INFO_AVAILABLE_FACE_DETECT_MODES);
-    if (fd == null || fd.length == 0) {
-      Log.e(TAG, "face detection unsupported");
-      return false;
-    }
-    Integer maxFD = characteristics.get(CameraCharacteristics.STATISTICS_INFO_MAX_FACE_COUNT);
-    if (maxFD == null || maxFD <= 0) {
-      Log.e(TAG, "face detection unsupported");
-      return false;
-    }
-    List<Integer> fdList = new ArrayList<>();
-    for (int FaceD : fd) {
-      fdList.add(FaceD);
-    }
-    this.faceDetectorCallback = faceDetectorCallback;
-    faceDetectionEnabled = true;
-    faceDetectionMode = Collections.max(fdList);
-    setFaceDetect(builderInputSurface, faceDetectionMode);
-    prepareFaceDetectionCallback();
-    return true;
-  }
-
-  public void disableFaceDetection() {
-    if (faceDetectionEnabled) {
-      faceDetectorCallback = null;
-      faceDetectionEnabled = false;
-      faceDetectionMode = 0;
-      prepareFaceDetectionCallback();
-    }
-  }
-
-  public boolean isFaceDetectionEnabled() {
-    return faceDetectorCallback != null;
-  }
-
-  private void setFaceDetect(CaptureRequest.Builder requestBuilder, int faceDetectMode) {
-    if (faceDetectionEnabled) {
-      requestBuilder.set(CaptureRequest.STATISTICS_FACE_DETECT_MODE, faceDetectMode);
-    }
-  }
-
-  public void setCameraCallbacks(CameraCallbacks cameraCallbacks) {
-    this.cameraCallbacks = cameraCallbacks;
-  }
-
-  private void prepareFaceDetectionCallback() {
-    try {
-      cameraCaptureSession.stopRepeating();
-      cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-          faceDetectionEnabled ? cb : null, null);
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
-    }
-  }
-
-  private final CameraCaptureSession.CaptureCallback cb =
-      new CameraCaptureSession.CaptureCallback() {
-
-        @Override
-        public void onCaptureCompleted(@NonNull CameraCaptureSession session,
-            @NonNull CaptureRequest request, @NonNull TotalCaptureResult result) {
-          Face[] faces = result.get(CaptureResult.STATISTICS_FACES);
-          if (faceDetectorCallback != null && faces != null) {
-            faceDetectorCallback.onGetFaces(UtilsKt.mapCamera2Faces(faces), faceSensorScale, sensorOrientation);
-          }
+    private void setModeAuto(CaptureRequest.Builder builderInputSurface) {
+        try {
+            builderInputSurface.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
+        } catch (Exception ignored) {
         }
-      };
+    }
 
-  @SuppressLint("MissingPermission")
-  public void openCameraId(String cameraId) {
-    this.cameraId = cameraId;
-    if (prepared) {
-      HandlerThread cameraHandlerThread = new HandlerThread(TAG + " Id = " + cameraId);
-      cameraHandlerThread.start();
-      cameraHandler = new Handler(cameraHandlerThread.getLooper());
-      try {
-        cameraManager.openCamera(cameraId, this, cameraHandler);
-        semaphore.acquireUninterruptibly();
-        CameraCharacteristics cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId);
-        running = true;
-        Integer facing = cameraCharacteristics.get(CameraCharacteristics.LENS_FACING);
-        if (facing == null) return;
-        this.facing = LENS_FACING_FRONT == facing ? CameraHelper.Facing.FRONT : CameraHelper.Facing.BACK;
-        if (cameraCallbacks != null) {
-          cameraCallbacks.onCameraChanged(this.facing);
+    private void adaptFpsRange(int expectedFps, CaptureRequest.Builder builderInputSurface) {
+        List<Range<Integer>> fpsRanges = getSupportedFps(null, Facing.BACK);
+        if (fpsRanges != null && fpsRanges.size() > 0) {
+            Range<Integer> closestRange = fpsRanges.get(0);
+            int measure = Math.abs(closestRange.getLower() - expectedFps) + Math.abs(
+                    closestRange.getUpper() - expectedFps);
+            for (Range<Integer> range : fpsRanges) {
+                if (CameraHelper.discardCamera2Fps(range, facing)) continue;
+                if (range.getLower() <= expectedFps && range.getUpper() >= expectedFps) {
+                    int curMeasure = Math.abs(((range.getLower() + range.getUpper()) / 2) - expectedFps);
+                    if (curMeasure < measure) {
+                        closestRange = range;
+                        measure = curMeasure;
+                    } else if (curMeasure == measure) {
+                        if (Math.abs(range.getUpper() - expectedFps) < Math.abs(closestRange.getUpper() - expectedFps)) {
+                            closestRange = range;
+                            measure = curMeasure;
+                        }
+                    }
+                }
+            }
+            Log.i(TAG, "fps: " + closestRange.getLower() + " - " + closestRange.getUpper());
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, closestRange);
         }
-      } catch (CameraAccessException | SecurityException e) {
-        if (cameraCallbacks != null) {
-          cameraCallbacks.onCameraError("Open camera " + cameraId + " failed");
+    }
+
+    public List<Range<Integer>> getSupportedFps(Size size, Facing facing) {
+        try {
+            CameraCharacteristics characteristics = null;
+            try {
+                characteristics = getCharacteristicsForFacing(cameraManager, facing);
+            } catch (CameraAccessException ignored) {
+            }
+            if (characteristics == null) return null;
+            Range<Integer>[] fpsSupported = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+            if (size != null) {
+                StreamConfigurationMap streamConfigurationMap =
+                        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+                List<Range<Integer>> list = new ArrayList<>();
+                long fd = streamConfigurationMap.getOutputMinFrameDuration(SurfaceTexture.class, size);
+                int maxFPS = (int) (10f / Float.parseFloat("0." + fd));
+                for (Range<Integer> r : fpsSupported) {
+                    if (r.getUpper() <= maxFPS) {
+                        list.add(r);
+                    }
+                }
+                return list;
+            } else {
+                return Arrays.asList(fpsSupported);
+            }
+        } catch (IllegalStateException e) {
+            Log.e(TAG, "Error", e);
+            return null;
         }
-        Log.e(TAG, "Error", e);
-      }
-    } else {
-      Log.e(TAG, "Camera2ApiManager need be prepared, Camera2ApiManager not enabled");
     }
-  }
 
-  public String[] getCamerasAvailable() {
-    try {
-      return cameraManager.getCameraIdList();
-    } catch (CameraAccessException e) {
-      return null;
+    public int getLevelSupported() {
+        try {
+            CameraCharacteristics characteristics = getCameraCharacteristics();
+            if (characteristics == null) return -1;
+            Integer level = characteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
+            if (level == null) return -1;
+            return level;
+        } catch (IllegalStateException e) {
+            Log.e(TAG, "Error", e);
+            return -1;
+        }
     }
-  }
 
-  public boolean isRunning() {
-    return running;
-  }
-
-  public void switchCamera() {
-    try {
-      String cameraId;
-      if (cameraDevice == null || facing == Facing.FRONT) {
-        cameraId = getCameraIdForFacing(cameraManager, Facing.BACK);
-      } else {
-        cameraId = getCameraIdForFacing(cameraManager, Facing.FRONT);
-      }
-      if (cameraId == null) cameraId = "0";
-      reOpenCamera(cameraId);
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
+    public void openCamera() {
+        openCameraBack();
     }
-  }
 
-  public void reOpenCamera(String cameraId) {
-    if (cameraDevice != null) {
-      closeCamera(false);
-      if (textureView != null) {
-        prepareCamera(textureView, surfaceEncoder, fps);
-      } else if (surfaceView != null) {
-        prepareCamera(surfaceView, surfaceEncoder, fps);
-      } else {
-        prepareCamera(surfaceEncoder, fps);
-      }
-      openCameraId(cameraId);
+    public void openCameraBack() {
+        openCameraFacing(Facing.BACK);
     }
-  }
 
-  public Range<Float> getZoomRange() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return new Range<>(1f, 1f);
-    Range<Float> zoomRanges = null;
-    //only camera limited or better support this feature.
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R &&
-        getLevelSupported() != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
-      zoomRanges = characteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE);
+    public void openCameraFront() {
+        openCameraFacing(Facing.FRONT);
     }
-    if (zoomRanges == null) {
-      Float maxZoom = characteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM);
-      if (maxZoom == null) maxZoom = 1f;
-      zoomRanges = new Range<>(1f, maxZoom);
+
+    public void openLastCamera() {
+        if (cameraId == null) {
+            openCameraBack();
+        } else {
+            openCameraId(cameraId);
+        }
     }
-    return zoomRanges;
-  }
 
-  public Float getZoom() {
-    return zoomLevel;
-  }
-
-  public float[] getOpticalZooms() {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return null;
-    return characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS);
-  }
-
-  public void setOpticalZoom(float level) {
-    CameraCharacteristics characteristics = getCameraCharacteristics();
-    if (characteristics == null) return;
-    if (builderInputSurface != null) {
-      try {
-        builderInputSurface.set(CaptureRequest.LENS_FOCAL_LENGTH, level);
-        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-            faceDetectionEnabled ? cb : null, null);
-      } catch (Exception e) {
-        Log.e(TAG, "Error", e);
-      }
+    public void setCameraFacing(CameraHelper.Facing cameraFacing) {
+        try {
+            String cameraId = getCameraIdForFacing(cameraManager, cameraFacing);
+            if (cameraId != null) {
+                facing = cameraFacing;
+                this.cameraId = cameraId;
+            }
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+        }
     }
-  }
 
-  public void setZoom(float level) {
-    try {
-      Range<Float> zoomRange = getZoomRange();
-      //Avoid out range level
-      if (level <= zoomRange.getLower()) level = zoomRange.getLower();
-      else if (level > zoomRange.getUpper()) level = zoomRange.getUpper();
+    public void setCameraId(String cameraId) {
+        this.cameraId = cameraId;
+    }
 
-      CameraCharacteristics characteristics = getCameraCharacteristics();
-      if (characteristics == null) return;
+    @Nullable
+    public String getCameraId() {
+        return this.cameraId;
+    }
 
-      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R &&
-          getLevelSupported() != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
-        builderInputSurface.set(CaptureRequest.CONTROL_ZOOM_RATIO, level);
-      } else {
+    public CameraHelper.Facing getCameraFacing() {
+        return facing;
+    }
+
+    public Size[] getCameraResolutionsBack() {
+        return getCameraResolutions(Facing.BACK);
+    }
+
+    public Size[] getCameraResolutionsFront() {
+        return getCameraResolutions(Facing.FRONT);
+    }
+
+    public Size[] getCameraResolutions(Facing facing) {
+        try {
+            CameraCharacteristics characteristics = getCharacteristicsForFacing(cameraManager, facing);
+            if (characteristics == null) {
+                return new Size[0];
+            }
+
+            StreamConfigurationMap streamConfigurationMap =
+                    characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+            if (streamConfigurationMap == null) return new Size[0];
+            Size[] outputSizes = streamConfigurationMap.getOutputSizes(SurfaceTexture.class);
+            return outputSizes != null ? outputSizes : new Size[0];
+        } catch (CameraAccessException | NullPointerException e) {
+            Log.e(TAG, "Error", e);
+            return new Size[0];
+        }
+    }
+
+    public Size[] getCameraResolutions(String cameraId) {
+        try {
+            CameraCharacteristics characteristics = getCharacteristicsForId(cameraManager, cameraId);
+            if (characteristics == null) {
+                return new Size[0];
+            }
+
+            StreamConfigurationMap streamConfigurationMap =
+                    characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+            if (streamConfigurationMap == null) return new Size[0];
+            Size[] outputSizes = streamConfigurationMap.getOutputSizes(SurfaceTexture.class);
+            return outputSizes != null ? outputSizes : new Size[0];
+        } catch (CameraAccessException | NullPointerException e) {
+            Log.e(TAG, "Error", e);
+            return new Size[0];
+        }
+    }
+
+    @Nullable
+    public CameraCharacteristics getCameraCharacteristics() {
+        try {
+            return cameraId != null ? cameraManager.getCameraCharacteristics(cameraId) : null;
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+            return null;
+        }
+    }
+
+    public boolean enableVideoStabilization() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return false;
+        int[] modes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES);
+        List<Integer> videoStabilizationList = new ArrayList<>();
+        for (int vsMode : modes) {
+            videoStabilizationList.add(vsMode);
+        }
+        if (!videoStabilizationList.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
+            Log.e(TAG, "video stabilization unsupported");
+            return false;
+        }
+
+        if (builderInputSurface != null) {
+            builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,
+                    CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON);
+            videoStabilizationEnable = true;
+        }
+        return videoStabilizationEnable;
+    }
+
+    public void disableVideoStabilization() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        int[] modes = characteristics.get(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES);
+        List<Integer> videoStabilizationList = new ArrayList<>();
+        for (int vsMode : modes) {
+            videoStabilizationList.add(vsMode);
+        }
+        if (!videoStabilizationList.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) {
+            Log.e(TAG, "video stabilization unsupported");
+            return;
+        }
+        if (builderInputSurface != null) {
+            builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,
+                    CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_OFF);
+            videoStabilizationEnable = false;
+        }
+    }
+
+    public boolean isVideoStabilizationEnabled() {
+        return videoStabilizationEnable;
+    }
+
+    public boolean enableOpticalVideoStabilization() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return false;
+
+        int[] opticalStabilizationModes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION);
+        List<Integer> opticalStabilizationList = new ArrayList<>();
+        for (int vsMode : opticalStabilizationModes) {
+            opticalStabilizationList.add(vsMode);
+        }
+
+        if (!opticalStabilizationList.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) {
+            Log.e(TAG, "OIS video stabilization unsupported");
+            return false;
+        }
+        if (builderInputSurface != null) {
+            builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE,
+                    CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON);
+            opticalVideoStabilizationEnable = true;
+        }
+        return opticalVideoStabilizationEnable;
+    }
+
+    public void disableOpticalVideoStabilization() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        int[] modes = characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION);
+        List<Integer> videoStabilizationList = new ArrayList<>();
+        for (int vsMode : modes) {
+            videoStabilizationList.add(vsMode);
+        }
+        if (!videoStabilizationList.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) {
+            Log.e(TAG, "OIS video stabilization unsupported");
+            return;
+        }
+        if (builderInputSurface != null) {
+            builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE,
+                    CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_OFF);
+            opticalVideoStabilizationEnable = false;
+        }
+    }
+
+    public boolean isOpticalStabilizationEnabled() {
+        return opticalVideoStabilizationEnable;
+    }
+
+    public void setFocusDistance(float distance) {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        if (builderInputSurface != null) {
+            try {
+                if (distance < 0) distance = 0f; //avoid invalid value
+                builderInputSurface.set(CaptureRequest.LENS_FOCUS_DISTANCE, distance);
+                cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                        faceDetectionEnabled ? cb : null, null);
+            } catch (Exception e) {
+                Log.e(TAG, "Error", e);
+            }
+        }
+    }
+
+    public void setExposure(int value) {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        Range<Integer> supportedExposure =
+                characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+        if (supportedExposure != null && builderInputSurface != null) {
+            if (value > supportedExposure.getUpper()) value = supportedExposure.getUpper();
+            if (value < supportedExposure.getLower()) value = supportedExposure.getLower();
+            try {
+                builderInputSurface.set(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, value);
+                cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                        faceDetectionEnabled ? cb : null, null);
+            } catch (Exception e) {
+                Log.e(TAG, "Error", e);
+            }
+        }
+    }
+
+    public int getExposure() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return 0;
+        if (builderInputSurface != null) {
+            try {
+                return builderInputSurface.get(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION);
+            } catch (Exception e) {
+                Log.e(TAG, "Error", e);
+            }
+        }
+        return 0;
+    }
+
+
+    public int getMaxExposure() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return 0;
+        Range<Integer> supportedExposure =
+                characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+        if (supportedExposure != null) {
+            return supportedExposure.getUpper();
+        }
+        return 0;
+    }
+
+    public int getMinExposure() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return 0;
+        Range<Integer> supportedExposure =
+                characteristics.get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+        if (supportedExposure != null) {
+            return supportedExposure.getLower();
+        }
+        return 0;
+    }
+
+    public void tapToFocus(View view, MotionEvent event) {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
         Rect rect = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
         if (rect == null) return;
-        //This ratio is the ratio of cropped Rect to Camera's original(Maximum) Rect
-        float ratio = 1f / level;
-        //croppedWidth and croppedHeight are the pixels cropped away, not pixels after cropped
-        int croppedWidth = rect.width() - Math.round((float) rect.width() * ratio);
-        int croppedHeight = rect.height() - Math.round((float) rect.height() * ratio);
-        //Finally, zoom represents the zoomed visible area
-        Rect zoom = new Rect(croppedWidth / 2, croppedHeight / 2, rect.width() - croppedWidth / 2,
-            rect.height() - croppedHeight / 2);
-        builderInputSurface.set(CaptureRequest.SCALER_CROP_REGION, zoom);
-      }
-      cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
-          faceDetectionEnabled ? cb : null, null);
-      zoomLevel = level;
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Error", e);
-    }
-  }
+        int pointerId = event.getPointerId(0);
+        int pointerIndex = event.findPointerIndex(pointerId);
+        // Get the pointer's current position
+        float x = event.getX(pointerIndex);
+        float y = event.getY(pointerIndex);
 
-  public void setZoom(MotionEvent event) {
-    float currentFingerSpacing;
-    if (event.getPointerCount() > 1) {
-      currentFingerSpacing = getFingerSpacing(event);
-      float delta = 0.1f;
-      if (fingerSpacing != 0) {
-        float newLevel = zoomLevel;
-        if (currentFingerSpacing > fingerSpacing) {
-          newLevel += delta;
-        } else if (currentFingerSpacing < fingerSpacing) {
-          newLevel -= delta;
+        // interpolate from view space to camera space
+        float normX = x / view.getWidth();
+        float normY = y / view.getHeight();
+        float sensorX = rect.left + (normX*rect.width());
+        float sensorY = rect.top + (normY*rect.height());
+
+        if (sensorX < 100 || sensorY < 100) return;
+
+////        Rect touchRect = new Rect((int) (x - 100), (int) (y - 100),
+////                (int) (x + 100), (int) (y + 100));
+//        Rect touchRect = new Rect((int) (950 - 100), (int) (1680 - 100),
+//                (int) (950 + 100), (int) (1680 + 100));
+        Rect focusRect = new Rect(
+                Math.max(rect.left,Math.round(sensorX-50)),
+                Math.max(rect.top,Math.round(sensorY-50)),
+                Math.min(rect.right,Math.round(sensorX+50)),
+                Math.min(rect.bottom,Math.round(sensorY+50)));
+
+        MeteringRectangle focusArea = new MeteringRectangle(focusRect, MeteringRectangle.METERING_WEIGHT_MAX);
+        if (builderInputSurface != null) {
+            try {
+                //cancel any existing AF trigger (repeated touches, etc.)
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    cameraCaptureSession.capture(builderInputSurface.build(), null, null);
+                }else {
+                    cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                            faceDetectionEnabled ? cb : null, null);
+                }
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_REGIONS, new MeteringRectangle[]{focusArea});
+                builderInputSurface.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_START);
+                cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                        faceDetectionEnabled ? cb : null, null);
+
+                // but only try for 5s and then give up
+//        cameraHandler.postDelayed()
+//        cameraCaptureSession.captureBurstRequests()
+            } catch (Exception e) {
+                Log.e(TAG, "Error", e);
+            }
         }
-        //This method avoid out of range
-        setZoom(newLevel);
-      }
-      fingerSpacing = currentFingerSpacing;
     }
-  }
 
-  private void resetCameraValues() {
-    lanternEnable = false;
-    zoomLevel = 1.0f;
-  }
+    /**
+     * Select camera facing
+     *
+     * @param selectedCameraFacing - CameraCharacteristics.LENS_FACING_FRONT,
+     *                             CameraCharacteristics.LENS_FACING_BACK,
+     *                             CameraCharacteristics.LENS_FACING_EXTERNAL
+     */
+    public void openCameraFacing(Facing selectedCameraFacing) {
+        try {
+            String cameraId = getCameraIdForFacing(cameraManager, selectedCameraFacing);
+            if (cameraId != null) {
+                openCameraId(cameraId);
+            } else {
+                Log.e(TAG, "Camera not supported"); // TODO maybe we want to throw some exception here?
+            }
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+        }
+    }
 
-  public void stopRepeatingEncoder() {
-    if (cameraCaptureSession != null) {
-      try {
-        cameraCaptureSession.stopRepeating();
-        surfaceEncoder = null;
-        Surface preview = addPreviewSurface();
-        if (preview != null) {
-          CaptureRequest captureRequest = drawSurface(Collections.singletonList(preview));
-          if (captureRequest != null) {
-            cameraCaptureSession.setRepeatingRequest(captureRequest, null, cameraHandler);
-          }
+    public boolean isLanternSupported() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return false;
+        Boolean available = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+        if (available == null) return false;
+        return available;
+    }
+
+    public boolean isLanternEnabled() {
+        return lanternEnable;
+    }
+
+    /**
+     * @required: <uses-permission android:name="android.permission.FLASHLIGHT"/>
+     */
+    public void enableLantern() throws Exception {
+        if (isLanternSupported()) {
+            if (builderInputSurface != null) {
+                try {
+                    builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_TORCH);
+                    cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                            faceDetectionEnabled ? cb : null, null);
+                    lanternEnable = true;
+                } catch (Exception e) {
+                    Log.e(TAG, "Error", e);
+                }
+            }
         } else {
-          Log.e(TAG, "preview surface is null");
+            Log.e(TAG, "Lantern unsupported");
+            throw new Exception("Lantern unsupported");
         }
-      } catch (CameraAccessException | IllegalStateException e) {
-        Log.e(TAG, "Error", e);
-      }
     }
-  }
 
-  public void closeCamera() {
-    closeCamera(true);
-  }
-
-  public void closeCamera(boolean resetSurface) {
-    resetCameraValues();
-    if (cameraCaptureSession != null) {
-      cameraCaptureSession.close();
-      cameraCaptureSession = null;
-    }
-    if (cameraDevice != null) {
-      cameraDevice.close();
-      cameraDevice = null;
-    }
-    if (cameraHandler != null) {
-      cameraHandler.getLooper().quitSafely();
-      cameraHandler = null;
-    }
-    if (resetSurface) {
-      surfaceEncoder = null;
-      builderInputSurface = null;
-    }
-    prepared = false;
-    running = false;
-  }
-
-  public void addImageListener(int width, int height, int format, int maxImages, boolean autoClose, ImageCallback listener) {
-    boolean wasRunning = running;
-    closeCamera(false);
-    if (wasRunning) closeCamera(false);
-    if (imageReader != null) removeImageListener();
-    HandlerThread imageThread = new HandlerThread(TAG + " imageThread");
-    imageThread.start();
-    imageReader = ImageReader.newInstance(width, height, format, maxImages);
-    imageReader.setOnImageAvailableListener(reader -> {
-      Image image = reader.acquireLatestImage();
-      if (image != null) {
-        listener.onImageAvailable(image);
-        if (autoClose) image.close();
-      }
-    }, new Handler(imageThread.getLooper()));
-    if (wasRunning) {
-      if (textureView != null) {
-        prepareCamera(textureView, surfaceEncoder, fps);
-      } else if (surfaceView != null) {
-        prepareCamera(surfaceView, surfaceEncoder, fps);
-      } else {
-        prepareCamera(surfaceEncoder, fps);
-      }
-      openLastCamera();
-    }
-  }
-
-  public void removeImageListener() {
-    boolean wasRunning = running;
-    if (wasRunning) closeCamera(false);
-    if (imageReader != null) {
-      imageReader.close();
-      imageReader = null;
-    }
-    if (wasRunning) {
-      if (textureView != null) {
-        prepareCamera(textureView, surfaceEncoder, fps);
-      } else if (surfaceView != null) {
-        prepareCamera(surfaceView, surfaceEncoder, fps);
-      } else {
-        prepareCamera(surfaceEncoder, fps);
-      }
-      openLastCamera();
-    }
-  }
-
-  @Override
-  public void onOpened(@NonNull CameraDevice cameraDevice) {
-    this.cameraDevice = cameraDevice;
-    startPreview(cameraDevice);
-    semaphore.release();
-    if (cameraCallbacks != null) cameraCallbacks.onCameraOpened();
-    Log.i(TAG, "Camera opened");
-  }
-
-  @Override
-  public void onDisconnected(@NonNull CameraDevice cameraDevice) {
-    cameraDevice.close();
-    semaphore.release();
-    if (cameraCallbacks != null) cameraCallbacks.onCameraDisconnected();
-    Log.i(TAG, "Camera disconnected");
-  }
-
-  @Override
-  public void onError(@NonNull CameraDevice cameraDevice, int i) {
-    cameraDevice.close();
-    semaphore.release();
-    if (cameraCallbacks != null) cameraCallbacks.onCameraError("Open camera failed: " + i);
-    Log.e(TAG, "Open failed: " + i);
-  }
-
-  @Nullable
-  private String getCameraIdForFacing(CameraManager cameraManager, CameraHelper.Facing facing)
-      throws CameraAccessException {
-    int selectedFacing = getFacing(facing);
-    for (String cameraId : cameraManager.getCameraIdList()) {
-      Integer cameraFacing =
-          cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING);
-      if (cameraFacing != null && cameraFacing == selectedFacing) {
-        return cameraId;
-      }
-    }
-    return null;
-  }
-
-  private Facing getFacingByCameraId(CameraManager cameraManager, String cameraId) {
-    try {
-      for (String id : cameraManager.getCameraIdList()) {
-        if (id.equals(cameraId)) {
-          Integer cameraFacing = cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING);
-          if (cameraFacing == CameraMetadata.LENS_FACING_BACK) return Facing.BACK;
-          else return Facing.FRONT;
+    /**
+     * @required: <uses-permission android:name="android.permission.FLASHLIGHT"/>
+     */
+    public void disableLantern() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        Boolean available = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+        if (available == null) return;
+        if (available) {
+            if (builderInputSurface != null) {
+                try {
+                    builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_OFF);
+                    cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                            faceDetectionEnabled ? cb : null, null);
+                    lanternEnable = false;
+                } catch (Exception e) {
+                    Log.e(TAG, "Error", e);
+                }
+            }
         }
-      }
-      return Facing.BACK;
-    } catch (CameraAccessException e) {
-      return Facing.BACK;
     }
-  }
 
-  @Nullable
-  public String getCameraIdForFacing(CameraHelper.Facing facing) {
-    try {
-      return getCameraIdForFacing(cameraManager, facing);
-    } catch (Exception e) {
-      return null;
+    public void enableAutoFocus() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        int[] supportedFocusModes =
+                characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
+        if (supportedFocusModes != null) {
+            List<Integer> focusModesList = new ArrayList<>();
+            for (int i : supportedFocusModes) focusModesList.add(i);
+            if (builderInputSurface != null) {
+                try {
+                    if (!focusModesList.isEmpty()) {
+                        //cancel any existing AF trigger
+                        builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
+                        builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+                        cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                                faceDetectionEnabled ? cb : null, null);
+                        if (focusModesList.contains(CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)) {
+                            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
+                                    CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+                            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                                    faceDetectionEnabled ? cb : null, null);
+                            autoFocusEnabled = true;
+                        } else if (focusModesList.contains(CaptureRequest.CONTROL_AF_MODE_AUTO)) {
+                            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
+                                    CaptureRequest.CONTROL_AF_MODE_AUTO);
+                            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                                    faceDetectionEnabled ? cb : null, null);
+                            autoFocusEnabled = true;
+                        } else {
+                            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, focusModesList.get(0));
+                            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                                    faceDetectionEnabled ? cb : null, null);
+                            autoFocusEnabled = false;
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "Error", e);
+                }
+            }
+        }
     }
-  }
 
-  @Nullable
-  private CameraCharacteristics getCharacteristicsForFacing(CameraManager cameraManager,
-      CameraHelper.Facing facing) throws CameraAccessException {
-    String cameraId = getCameraIdForFacing(cameraManager, facing);
-    return getCharacteristicsForId(cameraManager, cameraId);
-  }
+    public void disableAutoFocus() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        int[] supportedFocusModes =
+                characteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
+        if (supportedFocusModes != null) {
+            if (builderInputSurface != null) {
+                for (int mode : supportedFocusModes) {
+                    try {
+                        if (mode == CaptureRequest.CONTROL_AF_MODE_OFF) {
+                            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE,
+                                    CaptureRequest.CONTROL_AF_MODE_OFF);
+                            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                                    faceDetectionEnabled ? cb : null, null);
+                            autoFocusEnabled = false;
+                            return;
+                        }
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error", e);
+                    }
+                }
+            }
+        }
+    }
 
-  @Nullable
-  private CameraCharacteristics getCharacteristicsForId(CameraManager cameraManager,
-      String cameraId) throws CameraAccessException {
-    return cameraId != null ? cameraManager.getCameraCharacteristics(cameraId) : null;
-  }
+    public boolean isAutoFocusEnabled() {
+        return autoFocusEnabled;
+    }
 
-  private static int getFacing(CameraHelper.Facing facing) {
-    return facing == CameraHelper.Facing.BACK ? CameraMetadata.LENS_FACING_BACK
-        : CameraMetadata.LENS_FACING_FRONT;
-  }
+    public boolean enableFaceDetection(FaceDetectorCallback faceDetectorCallback) {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) {
+            Log.e(TAG, "face detection called with camera stopped");
+            return false;
+        }
+        faceSensorScale = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+        sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
+        int[] fd = characteristics.get(CameraCharacteristics.STATISTICS_INFO_AVAILABLE_FACE_DETECT_MODES);
+        if (fd == null || fd.length == 0) {
+            Log.e(TAG, "face detection unsupported");
+            return false;
+        }
+        Integer maxFD = characteristics.get(CameraCharacteristics.STATISTICS_INFO_MAX_FACE_COUNT);
+        if (maxFD == null || maxFD <= 0) {
+            Log.e(TAG, "face detection unsupported");
+            return false;
+        }
+        List<Integer> fdList = new ArrayList<>();
+        for (int FaceD : fd) {
+            fdList.add(FaceD);
+        }
+        this.faceDetectorCallback = faceDetectorCallback;
+        faceDetectionEnabled = true;
+        faceDetectionMode = Collections.max(fdList);
+        setFaceDetect(builderInputSurface, faceDetectionMode);
+        prepareFaceDetectionCallback();
+        return true;
+    }
+
+    public void disableFaceDetection() {
+        if (faceDetectionEnabled) {
+            faceDetectorCallback = null;
+            faceDetectionEnabled = false;
+            faceDetectionMode = 0;
+            prepareFaceDetectionCallback();
+        }
+    }
+
+    public boolean isFaceDetectionEnabled() {
+        return faceDetectorCallback != null;
+    }
+
+    private void setFaceDetect(CaptureRequest.Builder requestBuilder, int faceDetectMode) {
+        if (faceDetectionEnabled) {
+            requestBuilder.set(CaptureRequest.STATISTICS_FACE_DETECT_MODE, faceDetectMode);
+        }
+    }
+
+    public void setCameraCallbacks(CameraCallbacks cameraCallbacks) {
+        this.cameraCallbacks = cameraCallbacks;
+    }
+
+    private void prepareFaceDetectionCallback() {
+        try {
+            cameraCaptureSession.stopRepeating();
+            cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                    faceDetectionEnabled ? cb : null, null);
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+        }
+    }
+
+    private final CameraCaptureSession.CaptureCallback cb =
+            new CameraCaptureSession.CaptureCallback() {
+
+                @Override
+                public void onCaptureCompleted(@NonNull CameraCaptureSession session,
+                                               @NonNull CaptureRequest request, @NonNull TotalCaptureResult result) {
+                    Face[] faces = result.get(CaptureResult.STATISTICS_FACES);
+                    if (faceDetectorCallback != null && faces != null) {
+                        faceDetectorCallback.onGetFaces(UtilsKt.mapCamera2Faces(faces), faceSensorScale, sensorOrientation);
+                    }
+                }
+            };
+
+    @SuppressLint("MissingPermission")
+    public void openCameraId(String cameraId) {
+        this.cameraId = cameraId;
+        if (prepared) {
+            HandlerThread cameraHandlerThread = new HandlerThread(TAG + " Id = " + cameraId);
+            cameraHandlerThread.start();
+            cameraHandler = new Handler(cameraHandlerThread.getLooper());
+            try {
+                cameraManager.openCamera(cameraId, this, cameraHandler);
+                semaphore.acquireUninterruptibly();
+                CameraCharacteristics cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId);
+                running = true;
+                Integer facing = cameraCharacteristics.get(CameraCharacteristics.LENS_FACING);
+                if (facing == null) return;
+                this.facing = LENS_FACING_FRONT == facing ? CameraHelper.Facing.FRONT : CameraHelper.Facing.BACK;
+                if (cameraCallbacks != null) {
+                    cameraCallbacks.onCameraChanged(this.facing);
+                }
+            } catch (CameraAccessException | SecurityException e) {
+                if (cameraCallbacks != null) {
+                    cameraCallbacks.onCameraError("Open camera " + cameraId + " failed");
+                }
+                Log.e(TAG, "Error", e);
+            }
+        } else {
+            Log.e(TAG, "Camera2ApiManager need be prepared, Camera2ApiManager not enabled");
+        }
+    }
+
+    public String[] getCamerasAvailable() {
+        try {
+            return cameraManager.getCameraIdList();
+        } catch (CameraAccessException e) {
+            return null;
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void switchCamera() {
+        try {
+            String cameraId;
+            if (cameraDevice == null || facing == Facing.FRONT) {
+                cameraId = getCameraIdForFacing(cameraManager, Facing.BACK);
+            } else {
+                cameraId = getCameraIdForFacing(cameraManager, Facing.FRONT);
+            }
+            if (cameraId == null) cameraId = "0";
+            reOpenCamera(cameraId);
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+        }
+    }
+
+    public void reOpenCamera(String cameraId) {
+        if (cameraDevice != null) {
+            closeCamera(false);
+            if (textureView != null) {
+                prepareCamera(textureView, surfaceEncoder, fps);
+            } else if (surfaceView != null) {
+                prepareCamera(surfaceView, surfaceEncoder, fps);
+            } else {
+                prepareCamera(surfaceEncoder, fps);
+            }
+            openCameraId(cameraId);
+        }
+    }
+
+    public Range<Float> getZoomRange() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return new Range<>(1f, 1f);
+        Range<Float> zoomRanges = null;
+        //only camera limited or better support this feature.
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R &&
+                getLevelSupported() != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+            zoomRanges = characteristics.get(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE);
+        }
+        if (zoomRanges == null) {
+            Float maxZoom = characteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM);
+            if (maxZoom == null) maxZoom = 1f;
+            zoomRanges = new Range<>(1f, maxZoom);
+        }
+        return zoomRanges;
+    }
+
+    public Float getZoom() {
+        return zoomLevel;
+    }
+
+    public float[] getOpticalZooms() {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return null;
+        return characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS);
+    }
+
+    public void setOpticalZoom(float level) {
+        CameraCharacteristics characteristics = getCameraCharacteristics();
+        if (characteristics == null) return;
+        if (builderInputSurface != null) {
+            try {
+                builderInputSurface.set(CaptureRequest.LENS_FOCAL_LENGTH, level);
+                cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                        faceDetectionEnabled ? cb : null, null);
+            } catch (Exception e) {
+                Log.e(TAG, "Error", e);
+            }
+        }
+    }
+
+    public void setZoom(float level) {
+        try {
+            Range<Float> zoomRange = getZoomRange();
+            //Avoid out range level
+            if (level <= zoomRange.getLower()) level = zoomRange.getLower();
+            else if (level > zoomRange.getUpper()) level = zoomRange.getUpper();
+
+            CameraCharacteristics characteristics = getCameraCharacteristics();
+            if (characteristics == null) return;
+
+            if (builderInputSurface != null) {
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R &&
+                        getLevelSupported() != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_ZOOM_RATIO, level);
+                } else {
+                    Rect rect = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+                    if (rect == null) return;
+                    //This ratio is the ratio of cropped Rect to Camera's original(Maximum) Rect
+                    float ratio = 1f / level;
+                    //croppedWidth and croppedHeight are the pixels cropped away, not pixels after cropped
+                    int croppedWidth = rect.width() - Math.round((float) rect.width() * ratio);
+                    int croppedHeight = rect.height() - Math.round((float) rect.height() * ratio);
+                    //Finally, zoom represents the zoomed visible area
+                    Rect zoom = new Rect(croppedWidth / 2, croppedHeight / 2, rect.width() - croppedWidth / 2,
+                            rect.height() - croppedHeight / 2);
+                    builderInputSurface.set(CaptureRequest.SCALER_CROP_REGION, zoom);
+                }
+                cameraCaptureSession.setRepeatingRequest(builderInputSurface.build(),
+                        faceDetectionEnabled ? cb : null, null);
+                zoomLevel = level;
+            }
+        } catch (CameraAccessException e) {
+            Log.e(TAG, "Error", e);
+        }
+    }
+
+    public void setZoom(MotionEvent event) {
+        float currentFingerSpacing;
+        if (event.getPointerCount() > 1) {
+            currentFingerSpacing = getFingerSpacing(event);
+            float delta = 0.1f;
+            if (fingerSpacing != 0) {
+                float newLevel = zoomLevel;
+                if (currentFingerSpacing > fingerSpacing) {
+                    newLevel += delta;
+                } else if (currentFingerSpacing < fingerSpacing) {
+                    newLevel -= delta;
+                }
+                //This method avoid out of range
+                setZoom(newLevel);
+            }
+            fingerSpacing = currentFingerSpacing;
+        }
+    }
+
+    private void resetCameraValues() {
+        lanternEnable = false;
+        zoomLevel = 1.0f;
+    }
+
+    public void stopRepeatingEncoder() {
+        if (cameraCaptureSession != null) {
+            try {
+                cameraCaptureSession.stopRepeating();
+                surfaceEncoder = null;
+                Surface preview = addPreviewSurface();
+                if (preview != null) {
+                    CaptureRequest captureRequest = drawSurface(Collections.singletonList(preview));
+                    if (captureRequest != null) {
+                        cameraCaptureSession.setRepeatingRequest(captureRequest, null, cameraHandler);
+                    }
+                } else {
+                    Log.e(TAG, "preview surface is null");
+                }
+            } catch (CameraAccessException | IllegalStateException e) {
+                Log.e(TAG, "Error", e);
+            }
+        }
+    }
+
+    public void closeCamera() {
+        closeCamera(true);
+    }
+
+    public void closeCamera(boolean resetSurface) {
+        resetCameraValues();
+        if (cameraCaptureSession != null) {
+            cameraCaptureSession.close();
+            cameraCaptureSession = null;
+        }
+        if (cameraDevice != null) {
+            cameraDevice.close();
+            cameraDevice = null;
+        }
+        if (cameraHandler != null) {
+            cameraHandler.getLooper().quitSafely();
+            cameraHandler = null;
+        }
+        if (resetSurface) {
+            surfaceEncoder = null;
+            builderInputSurface = null;
+        }
+        prepared = false;
+        running = false;
+    }
+
+    public void addImageListener(int width, int height, int format, int maxImages, boolean autoClose, ImageCallback listener) {
+        boolean wasRunning = running;
+        closeCamera(false);
+        if (wasRunning) closeCamera(false);
+        if (imageReader != null) removeImageListener();
+        HandlerThread imageThread = new HandlerThread(TAG + " imageThread");
+        imageThread.start();
+        imageReader = ImageReader.newInstance(width, height, format, maxImages);
+        imageReader.setOnImageAvailableListener(reader -> {
+            Image image = reader.acquireLatestImage();
+            if (image != null) {
+                listener.onImageAvailable(image);
+                if (autoClose) image.close();
+            }
+        }, new Handler(imageThread.getLooper()));
+        if (wasRunning) {
+            if (textureView != null) {
+                prepareCamera(textureView, surfaceEncoder, fps);
+            } else if (surfaceView != null) {
+                prepareCamera(surfaceView, surfaceEncoder, fps);
+            } else {
+                prepareCamera(surfaceEncoder, fps);
+            }
+            openLastCamera();
+        }
+    }
+
+    public void removeImageListener() {
+        boolean wasRunning = running;
+        if (wasRunning) closeCamera(false);
+        if (imageReader != null) {
+            imageReader.close();
+            imageReader = null;
+        }
+        if (wasRunning) {
+            if (textureView != null) {
+                prepareCamera(textureView, surfaceEncoder, fps);
+            } else if (surfaceView != null) {
+                prepareCamera(surfaceView, surfaceEncoder, fps);
+            } else {
+                prepareCamera(surfaceEncoder, fps);
+            }
+            openLastCamera();
+        }
+    }
+
+    @Override
+    public void onOpened(@NonNull CameraDevice cameraDevice) {
+        this.cameraDevice = cameraDevice;
+        startPreview(cameraDevice);
+        semaphore.release();
+        if (cameraCallbacks != null) cameraCallbacks.onCameraOpened();
+        Log.i(TAG, "Camera opened");
+    }
+
+    @Override
+    public void onDisconnected(@NonNull CameraDevice cameraDevice) {
+        cameraDevice.close();
+        semaphore.release();
+        if (cameraCallbacks != null) cameraCallbacks.onCameraDisconnected();
+        Log.i(TAG, "Camera disconnected");
+    }
+
+    @Override
+    public void onError(@NonNull CameraDevice cameraDevice, int i) {
+        cameraDevice.close();
+        semaphore.release();
+        if (cameraCallbacks != null) cameraCallbacks.onCameraError("Open camera failed: " + i);
+        Log.e(TAG, "Open failed: " + i);
+    }
+
+    @Nullable
+    private String getCameraIdForFacing(CameraManager cameraManager, CameraHelper.Facing facing)
+            throws CameraAccessException {
+        int selectedFacing = getFacing(facing);
+        for (String cameraId : cameraManager.getCameraIdList()) {
+            Integer cameraFacing =
+                    cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING);
+            if (cameraFacing != null && cameraFacing == selectedFacing) {
+                return cameraId;
+            }
+        }
+        return null;
+    }
+
+    private Facing getFacingByCameraId(CameraManager cameraManager, String cameraId) {
+        try {
+            for (String id : cameraManager.getCameraIdList()) {
+                if (id.equals(cameraId)) {
+                    Integer cameraFacing = cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING);
+                    if (cameraFacing == CameraMetadata.LENS_FACING_BACK) return Facing.BACK;
+                    else return Facing.FRONT;
+                }
+            }
+            return Facing.BACK;
+        } catch (CameraAccessException e) {
+            return Facing.BACK;
+        }
+    }
+
+    @Nullable
+    public String getCameraIdForFacing(CameraHelper.Facing facing) {
+        try {
+            return getCameraIdForFacing(cameraManager, facing);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private CameraCharacteristics getCharacteristicsForFacing(CameraManager cameraManager,
+                                                              CameraHelper.Facing facing) throws CameraAccessException {
+        String cameraId = getCameraIdForFacing(cameraManager, facing);
+        return getCharacteristicsForId(cameraManager, cameraId);
+    }
+
+    @Nullable
+    private CameraCharacteristics getCharacteristicsForId(CameraManager cameraManager,
+                                                          String cameraId) throws CameraAccessException {
+        return cameraId != null ? cameraManager.getCameraCharacteristics(cameraId) : null;
+    }
+
+    private static int getFacing(CameraHelper.Facing facing) {
+        return facing == CameraHelper.Facing.BACK ? CameraMetadata.LENS_FACING_BACK
+                : CameraMetadata.LENS_FACING_FRONT;
+    }
 }

--- a/library/src/main/java/com/pedro/library/base/Camera2Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera2Base.java
@@ -30,6 +30,7 @@ import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceView;
 import android.view.TextureView;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -73,1007 +74,1021 @@ import java.util.List;
  * Wrapper to stream with camera2 api and microphone. Support stream with SurfaceView, TextureView,
  * OpenGlView(Custom SurfaceView that use OpenGl) and Context(background mode). All views use
  * Surface to buffer encoding mode for H264.
- *
+ * <p>
  * API requirements:
  * API 21+.
- *
+ * <p>
  * Created by pedro on 7/07/17.
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public abstract class Camera2Base {
 
-  private static final String TAG = "Camera2Base";
+    private static final String TAG = "Camera2Base";
 
-  private final Context context;
-  private Camera2ApiManager cameraManager;
-  protected VideoEncoder videoEncoder;
-  private MicrophoneManager microphoneManager;
-  private AudioEncoder audioEncoder;
-  private boolean streaming = false;
-  private SurfaceView surfaceView;
-  private TextureView textureView;
-  private GlInterface glInterface;
-  protected boolean audioInitialized = false;
-  private boolean onPreview = false;
-  private boolean isBackground = false;
-  protected BaseRecordController recordController;
-  private int previewWidth, previewHeight;
-  private final FpsListener fpsListener = new FpsListener();
+    private final Context context;
+    private Camera2ApiManager cameraManager;
+    protected VideoEncoder videoEncoder;
+    private MicrophoneManager microphoneManager;
+    private AudioEncoder audioEncoder;
+    private boolean streaming = false;
+    private SurfaceView surfaceView;
+    private TextureView textureView;
+    private GlInterface glInterface;
+    protected boolean audioInitialized = false;
+    private boolean onPreview = false;
+    private boolean isBackground = false;
+    protected BaseRecordController recordController;
+    private int previewWidth, previewHeight;
+    private final FpsListener fpsListener = new FpsListener();
 
-  /**
-   * @deprecated This view produce rotations problems and could be unsupported in future versions.
-   * Use {@link Camera2Base#Camera2Base(OpenGlView)}
-   * instead.
-   */
-  @Deprecated
-  public Camera2Base(SurfaceView surfaceView) {
-    this.surfaceView = surfaceView;
-    this.context = surfaceView.getContext();
-    init(context);
-  }
-
-  /**
-   * @deprecated This view produce rotations problems and could be unsupported in future versions.
-   * Use {@link Camera2Base#Camera2Base(OpenGlView)}
-   * instead.
-   */
-  @Deprecated
-  public Camera2Base(TextureView textureView) {
-    this.textureView = textureView;
-    this.context = textureView.getContext();
-    init(context);
-  }
-
-  public Camera2Base(OpenGlView openGlView) {
-    context = openGlView.getContext();
-    glInterface = openGlView;
-    init(context);
-  }
-
-  public Camera2Base(Context context, boolean useOpengl) {
-    this.context = context;
-    if (useOpengl) {
-      glInterface = new GlStreamInterface(context);
+    /**
+     * @deprecated This view produce rotations problems and could be unsupported in future versions.
+     * Use {@link Camera2Base#Camera2Base(OpenGlView)}
+     * instead.
+     */
+    @Deprecated
+    public Camera2Base(SurfaceView surfaceView) {
+        this.surfaceView = surfaceView;
+        this.context = surfaceView.getContext();
+        init(context);
     }
-    isBackground = true;
-    init(context);
-  }
 
-  private void init(Context context) {
-    cameraManager = new Camera2ApiManager(context);
-    videoEncoder = new VideoEncoder(getVideoData);
-    setMicrophoneMode(MicrophoneMode.ASYNC);
-    recordController = new AndroidMuxerRecordController();
-  }
-
-  /**
-   * Must be called before prepareAudio.
-   *
-   * @param microphoneMode mode to work accord to audioEncoder. By default ASYNC:
-   * SYNC using same thread. This mode could solve choppy audio or AudioEncoder frame discarded.
-   * ASYNC using other thread.
-   */
-  public void setMicrophoneMode(MicrophoneMode microphoneMode) {
-    switch (microphoneMode) {
-      case SYNC:
-        microphoneManager = new MicrophoneManagerManual();
-        audioEncoder = new AudioEncoder(getAacData);
-        audioEncoder.setGetFrame(((MicrophoneManagerManual) microphoneManager).getGetFrame());
-        audioEncoder.setTsModeBuffer(false);
-        break;
-      case ASYNC:
-        microphoneManager = new MicrophoneManager(getMicrophoneData);
-        audioEncoder = new AudioEncoder(getAacData);
-        audioEncoder.setTsModeBuffer(false);
-        break;
-      case BUFFER:
-        microphoneManager = new MicrophoneManager(getMicrophoneData);
-        audioEncoder = new AudioEncoder(getAacData);
-        audioEncoder.setTsModeBuffer(true);
-        break;
+    /**
+     * @deprecated This view produce rotations problems and could be unsupported in future versions.
+     * Use {@link Camera2Base#Camera2Base(OpenGlView)}
+     * instead.
+     */
+    @Deprecated
+    public Camera2Base(TextureView textureView) {
+        this.textureView = textureView;
+        this.context = textureView.getContext();
+        init(context);
     }
-  }
 
-  public void setCameraCallbacks(CameraCallbacks callbacks) {
-    cameraManager.setCameraCallbacks(callbacks);
-  }
-
-  /**
-   * Set a callback to know errors related with Video/Audio encoders
-   * @param encoderErrorCallback callback to use, null to remove
-   */
-  public void setEncoderErrorCallback(EncoderErrorCallback encoderErrorCallback) {
-    videoEncoder.setEncoderErrorCallback(encoderErrorCallback);
-    audioEncoder.setEncoderErrorCallback(encoderErrorCallback);
-  }
-
-  /**
-   * Set an audio effect modifying microphone's PCM buffer.
-   */
-  public void setCustomAudioEffect(CustomAudioEffect customAudioEffect) {
-    microphoneManager.setCustomAudioEffect(customAudioEffect);
-  }
-
-  /**
-   * @param callback get fps while record or stream
-   */
-  public void setFpsListener(FpsListener.Callback callback) {
-    fpsListener.setCallback(callback);
-  }
-
-  /**
-   * @return true if success, false if fail (not supported or called before start camera)
-   */
-  public boolean enableFaceDetection(FaceDetectorCallback faceDetectorCallback) {
-    return cameraManager.enableFaceDetection(faceDetectorCallback);
-  }
-
-  public void disableFaceDetection() {
-    cameraManager.disableFaceDetection();
-  }
-
-  public boolean isFaceDetectionEnabled() {
-    return cameraManager.isFaceDetectionEnabled();
-  }
-
-  /**
-   * Enable EIS video stabilization
-   * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
-   * @return true if success, false if fail (not supported or called before start camera)
-   */
-  public boolean enableVideoStabilization() {
-    return cameraManager.enableVideoStabilization();
-  }
-
-  public void disableVideoStabilization() {
-    cameraManager.disableVideoStabilization();
-  }
-
-  public boolean isVideoStabilizationEnabled() {
-    return cameraManager.isVideoStabilizationEnabled();
-  }
-
-  /**
-   * Enable OIS video stabilization
-   * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
-   * @return true if success, false if fail (not supported or called before start camera)
-   */
-  public boolean enableOpticalVideoStabilization() {
-    return cameraManager.enableOpticalVideoStabilization();
-  }
-
-  public void disableOpticalVideoStabilization() {
-    cameraManager.disableOpticalVideoStabilization();
-  }
-
-  public boolean isOpticalVideoStabilizationEnabled() {
-    return cameraManager.isOpticalStabilizationEnabled();
-  }
-
-  /**
-   * Use getCameraFacing instead
-   */
-  @Deprecated
-  public boolean isFrontCamera() {
-    return cameraManager.getCameraFacing() == CameraHelper.Facing.FRONT;
-  }
-
-  public CameraHelper.Facing getCameraFacing() {
-    return cameraManager.getCameraFacing();
-  }
-
-  public void enableLantern() throws Exception {
-    cameraManager.enableLantern();
-  }
-
-  public void disableLantern() {
-    cameraManager.disableLantern();
-  }
-
-  public boolean isLanternEnabled() {
-    return cameraManager.isLanternEnabled();
-  }
-
-  public boolean isLanternSupported() {
-    return cameraManager.isLanternSupported();
-  }
-
-  public void enableAutoFocus() {
-    cameraManager.enableAutoFocus();
-  }
-
-  public void disableAutoFocus() {
-    cameraManager.disableAutoFocus();
-  }
-
-  public boolean isAutoFocusEnabled() {
-    return cameraManager.isAutoFocusEnabled();
-  }
-
-  public void setFocusDistance(float distance) {
-    cameraManager.setFocusDistance(distance);
-  }
-
-  /**
-   * Call this method before use @startStream. If not you will do a stream without video.
-   *
-   * @param width resolution in px.
-   * @param height resolution in px.
-   * @param fps frames per second of the stream.
-   * @param bitrate H264 in bps.
-   * @param rotation could be 90, 180, 270 or 0 (Normally 0 if you are streaming in landscape or 90
-   * @param profile codec value from MediaCodecInfo.CodecProfileLevel class
-   * @param level codec value from MediaCodecInfo.CodecProfileLevel class
-   * if you are streaming in Portrait). This only affect to stream result. NOTE: Rotation with
-   * encoder is silence ignored in some devices.
-   * @return true if success, false if you get a error (Normally because the encoder selected
-   * doesn't support any configuration seated or your device hasn't a H264 encoder).
-   */
-  public boolean prepareVideo(int width, int height, int fps, int bitrate, int iFrameInterval,
-      int rotation, int profile, int level) {
-    if (onPreview && glInterface != null && (width != previewWidth || height != previewHeight
-        || fps != videoEncoder.getFps() || rotation != videoEncoder.getRotation())) {
-      stopPreview();
-      onPreview = true;
+    public Camera2Base(OpenGlView openGlView) {
+        context = openGlView.getContext();
+        glInterface = openGlView;
+        init(context);
     }
-    boolean result = videoEncoder.prepareVideoEncoder(width, height, fps, bitrate, rotation,
-        iFrameInterval, FormatVideoEncoder.SURFACE, profile, level);
-    prepareCameraManager();
-    return result;
-  }
 
-  public boolean prepareVideo(int width, int height, int fps, int bitrate, int iFrameInterval,
-      int rotation) {
-    return prepareVideo(width, height, fps, bitrate, iFrameInterval, rotation, -1, -1);
-  }
-
-  /**
-   * backward compatibility reason
-   */
-  public boolean prepareVideo(int width, int height, int fps, int bitrate, int rotation) {
-    return prepareVideo(width, height, fps, bitrate, 2, rotation);
-  }
-
-  public boolean prepareVideo(int width, int height, int bitrate) {
-    int rotation = CameraHelper.getCameraOrientation(context);
-    return prepareVideo(width, height, 30, bitrate, 2, rotation);
-  }
-
-  protected abstract void prepareAudioRtp(boolean isStereo, int sampleRate);
-
-  /**
-   * Call this method before use @startStream. If not you will do a stream without audio.
-   *
-   * @param bitrate AAC in kb.
-   * @param sampleRate of audio in hz. Can be 8000, 16000, 22500, 32000, 44100.
-   * @param isStereo true if you want Stereo audio (2 audio channels), false if you want Mono audio
-   * (1 audio channel).
-   * @param echoCanceler true enable echo canceler, false disable.
-   * @param noiseSuppressor true enable noise suppressor, false  disable.
-   * @return true if success, false if you get a error (Normally because the encoder selected
-   * doesn't support any configuration seated or your device hasn't a AAC encoder).
-   */
-  public boolean prepareAudio(int audioSource, int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
-      boolean noiseSuppressor) {
-    if (!microphoneManager.createMicrophone(audioSource, sampleRate, isStereo, echoCanceler, noiseSuppressor)) {
-      return false;
-    }
-    prepareAudioRtp(isStereo, sampleRate);
-    audioInitialized = audioEncoder.prepareAudioEncoder(bitrate, sampleRate, isStereo,
-        microphoneManager.getMaxInputSize());
-    return audioInitialized;
-  }
-
-  public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
-      boolean noiseSuppressor) {
-    return prepareAudio(MediaRecorder.AudioSource.DEFAULT, bitrate, sampleRate, isStereo, echoCanceler,
-        noiseSuppressor);
-  }
-
-  public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo) {
-    return prepareAudio(bitrate, sampleRate, isStereo, false, false);
-  }
-
-  /**
-   * Same to call: isHardwareRotation = true; if (openGlVIew) isHardwareRotation = false;
-   * prepareVideo(640, 480, 30, 1200 * 1024, isHardwareRotation, 90);
-   *
-   * @return true if success, false if you get a error (Normally because the encoder selected
-   * doesn't support any configuration seated or your device hasn't a H264 encoder).
-   */
-  public boolean prepareVideo() {
-    int rotation = CameraHelper.getCameraOrientation(context);
-    return prepareVideo(640, 480, 30, 1200 * 1024, rotation);
-  }
-
-  /**
-   * Same to call: prepareAudio(64 * 1024, 32000, true, false, false);
-   *
-   * @return true if success, false if you get a error (Normally because the encoder selected
-   * doesn't support any configuration seated or your device hasn't a AAC encoder).
-   */
-  public boolean prepareAudio() {
-    return prepareAudio(64 * 1024, 32000, true, false, false);
-  }
-
-  /**
-   * @param codecTypeVideo force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
-   * @param codecTypeAudio force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
-   */
-  public void forceCodecType(CodecUtil.CodecType codecTypeVideo, CodecUtil.CodecType codecTypeAudio) {
-    videoEncoder.forceCodecType(codecTypeVideo);
-    audioEncoder.forceCodecType(codecTypeAudio);
-  }
-
-  /**
-   * Starts recording a MP4 video.
-   *
-   * @param path Where file will be saved.
-   * @throws IOException If initialized before a stream.
-   */
-  public void startRecord(@NonNull String path, @Nullable RecordController.Listener listener)
-      throws IOException {
-    recordController.startRecord(path, listener);
-    if (!streaming) {
-      startEncoders();
-    } else if (videoEncoder.isRunning()) {
-      requestKeyFrame();
-    }
-  }
-
-  public void startRecord(@NonNull final String path) throws IOException {
-    startRecord(path, null);
-  }
-
-  /**
-   * Starts recording a MP4 video.
-   *
-   * @param fd Where the file will be saved.
-   * @throws IOException If initialized before a stream.
-   */
-  @RequiresApi(api = Build.VERSION_CODES.O)
-  public void startRecord(@NonNull final FileDescriptor fd,
-      @Nullable RecordController.Listener listener) throws IOException {
-    recordController.startRecord(fd, listener);
-    if (!streaming) {
-      startEncoders();
-    } else if (videoEncoder.isRunning()) {
-      requestKeyFrame();
-    }
-  }
-
-  @RequiresApi(api = Build.VERSION_CODES.O)
-  public void startRecord(@NonNull final FileDescriptor fd) throws IOException {
-    startRecord(fd, null);
-  }
-
-  /**
-   * Stop record MP4 video started with @startRecord. If you don't call it file will be unreadable.
-   */
-  public void stopRecord() {
-    recordController.stopRecord();
-    if (!streaming) stopStream();
-  }
-
-  public void replaceView(Context context) {
-    isBackground = true;
-    replaceGlInterface(new GlStreamInterface(context));
-  }
-
-  public void replaceView(OpenGlView openGlView) {
-    isBackground = false;
-    replaceGlInterface(openGlView);
-  }
-
-  /**
-   * Replace glInterface used on fly. Ignored if you use SurfaceView, TextureView or context without
-   * OpenGl.
-   */
-  private void replaceGlInterface(GlInterface glInterface) {
-    if (this.glInterface != null && Build.VERSION.SDK_INT >= 18) {
-      if (isStreaming() || isRecording() || isOnPreview()) {
-        Point size = this.glInterface.getEncoderSize();
-        cameraManager.closeCamera();
-        this.glInterface.removeMediaCodecSurface();
-        this.glInterface.stop();
-        this.glInterface = glInterface;
-        this.glInterface.setEncoderSize(size.x, size.y);
-        this.glInterface.setRotation(videoEncoder.getRotation() == 0 ? 270 : videoEncoder.getRotation() - 90);
-        this.glInterface.start();
-        if (isStreaming() || isRecording()) {
-          this.glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
+    public Camera2Base(Context context, boolean useOpengl) {
+        this.context = context;
+        if (useOpengl) {
+            glInterface = new GlStreamInterface(context);
         }
-        cameraManager.prepareCamera(this.glInterface.getSurfaceTexture(), videoEncoder.getWidth(),
-            videoEncoder.getHeight(), videoEncoder.getFps());
-        cameraManager.openLastCamera();
-      } else {
-        this.glInterface = glInterface;
-      }
+        isBackground = true;
+        init(context);
     }
-  }
 
-  /**
-   * Start camera preview. Ignored, if stream or preview is started.
-   *
-   * @param cameraFacing front or back camera. Like: {@link com.pedro.encoder.input.video.CameraHelper.Facing#BACK}
-   * {@link com.pedro.encoder.input.video.CameraHelper.Facing#FRONT}
-   * @param rotation camera rotation (0, 90, 180, 270). Recommended: {@link
-   * com.pedro.encoder.input.video.CameraHelper#getCameraOrientation(Context)}
-   */
-  public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int fps, int rotation) {
-    startPreview(cameraManager.getCameraIdForFacing(cameraFacing), width, height, fps, rotation);
-  }
+    private void init(Context context) {
+        cameraManager = new Camera2ApiManager(context);
+        videoEncoder = new VideoEncoder(getVideoData);
+        setMicrophoneMode(MicrophoneMode.ASYNC);
+        recordController = new AndroidMuxerRecordController();
+    }
 
-  public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int rotation) {
-    startPreview(cameraFacing, width, height, videoEncoder.getFps(), rotation);
-  }
+    /**
+     * Must be called before prepareAudio.
+     *
+     * @param microphoneMode mode to work accord to audioEncoder. By default ASYNC:
+     *                       SYNC using same thread. This mode could solve choppy audio or AudioEncoder frame discarded.
+     *                       ASYNC using other thread.
+     */
+    public void setMicrophoneMode(MicrophoneMode microphoneMode) {
+        switch (microphoneMode) {
+            case SYNC:
+                microphoneManager = new MicrophoneManagerManual();
+                audioEncoder = new AudioEncoder(getAacData);
+                audioEncoder.setGetFrame(((MicrophoneManagerManual) microphoneManager).getGetFrame());
+                audioEncoder.setTsModeBuffer(false);
+                break;
+            case ASYNC:
+                microphoneManager = new MicrophoneManager(getMicrophoneData);
+                audioEncoder = new AudioEncoder(getAacData);
+                audioEncoder.setTsModeBuffer(false);
+                break;
+            case BUFFER:
+                microphoneManager = new MicrophoneManager(getMicrophoneData);
+                audioEncoder = new AudioEncoder(getAacData);
+                audioEncoder.setTsModeBuffer(true);
+                break;
+        }
+    }
 
-  public void startPreview(String cameraId, int width, int height, int rotation) {
-    startPreview(cameraId, width, height, videoEncoder.getFps(), rotation);
-  }
+    public void setCameraCallbacks(CameraCallbacks callbacks) {
+        cameraManager.setCameraCallbacks(callbacks);
+    }
 
-  public void startPreview(String cameraId, int width, int height, int fps, int rotation) {
-    if (!isStreaming() && !onPreview && !isBackground) {
-      previewWidth = width;
-      previewHeight = height;
-      videoEncoder.setFps(fps);
-      videoEncoder.setRotation(rotation);
-      if (surfaceView != null) {
-        cameraManager.prepareCamera(surfaceView.getHolder().getSurface(), videoEncoder.getFps());
-      } else if (textureView != null) {
-        cameraManager.prepareCamera(new Surface(textureView.getSurfaceTexture()),
-            videoEncoder.getFps());
-      } else if (glInterface != null) {
+    /**
+     * Set a callback to know errors related with Video/Audio encoders
+     *
+     * @param encoderErrorCallback callback to use, null to remove
+     */
+    public void setEncoderErrorCallback(EncoderErrorCallback encoderErrorCallback) {
+        videoEncoder.setEncoderErrorCallback(encoderErrorCallback);
+        audioEncoder.setEncoderErrorCallback(encoderErrorCallback);
+    }
+
+    /**
+     * Set an audio effect modifying microphone's PCM buffer.
+     */
+    public void setCustomAudioEffect(CustomAudioEffect customAudioEffect) {
+        microphoneManager.setCustomAudioEffect(customAudioEffect);
+    }
+
+    /**
+     * @param callback get fps while record or stream
+     */
+    public void setFpsListener(FpsListener.Callback callback) {
+        fpsListener.setCallback(callback);
+    }
+
+    /**
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableFaceDetection(FaceDetectorCallback faceDetectorCallback) {
+        return cameraManager.enableFaceDetection(faceDetectorCallback);
+    }
+
+    public void disableFaceDetection() {
+        cameraManager.disableFaceDetection();
+    }
+
+    public boolean isFaceDetectionEnabled() {
+        return cameraManager.isFaceDetectionEnabled();
+    }
+
+    /**
+     * Enable EIS video stabilization
+     * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
+     *
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableVideoStabilization() {
+        return cameraManager.enableVideoStabilization();
+    }
+
+    public void disableVideoStabilization() {
+        cameraManager.disableVideoStabilization();
+    }
+
+    public boolean isVideoStabilizationEnabled() {
+        return cameraManager.isVideoStabilizationEnabled();
+    }
+
+    /**
+     * Enable OIS video stabilization
+     * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
+     *
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableOpticalVideoStabilization() {
+        return cameraManager.enableOpticalVideoStabilization();
+    }
+
+    public void disableOpticalVideoStabilization() {
+        cameraManager.disableOpticalVideoStabilization();
+    }
+
+    public boolean isOpticalVideoStabilizationEnabled() {
+        return cameraManager.isOpticalStabilizationEnabled();
+    }
+
+    /**
+     * Use getCameraFacing instead
+     */
+    @Deprecated
+    public boolean isFrontCamera() {
+        return cameraManager.getCameraFacing() == CameraHelper.Facing.FRONT;
+    }
+
+    public CameraHelper.Facing getCameraFacing() {
+        return cameraManager.getCameraFacing();
+    }
+
+    public String getCameraId() {
+        return cameraManager.getCameraId();
+    }
+
+    public String getCameraIdForFacing(CameraHelper.Facing facing) {
+        return cameraManager.getCameraIdForFacing(facing);
+    }
+
+    public void enableLantern() throws Exception {
+        cameraManager.enableLantern();
+    }
+
+    public void disableLantern() {
+        cameraManager.disableLantern();
+    }
+
+    public boolean isLanternEnabled() {
+        return cameraManager.isLanternEnabled();
+    }
+
+    public boolean isLanternSupported() {
+        return cameraManager.isLanternSupported();
+    }
+
+    public void enableAutoFocus() {
+        cameraManager.enableAutoFocus();
+    }
+
+    public void disableAutoFocus() {
+        cameraManager.disableAutoFocus();
+    }
+
+    public boolean isAutoFocusEnabled() {
+        return cameraManager.isAutoFocusEnabled();
+    }
+
+    public void setFocusDistance(float distance) {
+        cameraManager.setFocusDistance(distance);
+    }
+
+    /**
+     * Call this method before use @startStream. If not you will do a stream without video.
+     *
+     * @param width    resolution in px.
+     * @param height   resolution in px.
+     * @param fps      frames per second of the stream.
+     * @param bitrate  H264 in bps.
+     * @param rotation could be 90, 180, 270 or 0 (Normally 0 if you are streaming in landscape or 90
+     * @param profile  codec value from MediaCodecInfo.CodecProfileLevel class
+     * @param level    codec value from MediaCodecInfo.CodecProfileLevel class
+     *                 if you are streaming in Portrait). This only affect to stream result. NOTE: Rotation with
+     *                 encoder is silence ignored in some devices.
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a H264 encoder).
+     */
+    public boolean prepareVideo(int width, int height, int fps, int bitrate, int iFrameInterval,
+                                int rotation, int profile, int level) {
+        if (onPreview && glInterface != null && (width != previewWidth || height != previewHeight
+                || fps != videoEncoder.getFps() || rotation != videoEncoder.getRotation())) {
+            stopPreview();
+            onPreview = true;
+        }
+        boolean result = videoEncoder.prepareVideoEncoder(width, height, fps, bitrate, rotation,
+                iFrameInterval, FormatVideoEncoder.SURFACE, profile, level);
+        prepareCameraManager();
+        return result;
+    }
+
+    public boolean prepareVideo(int width, int height, int fps, int bitrate, int iFrameInterval,
+                                int rotation) {
+        return prepareVideo(width, height, fps, bitrate, iFrameInterval, rotation, -1, -1);
+    }
+
+    /**
+     * backward compatibility reason
+     */
+    public boolean prepareVideo(int width, int height, int fps, int bitrate, int rotation) {
+        return prepareVideo(width, height, fps, bitrate, 2, rotation);
+    }
+
+    public boolean prepareVideo(int width, int height, int bitrate) {
+        int rotation = CameraHelper.getCameraOrientation(context);
+        return prepareVideo(width, height, 30, bitrate, 2, rotation);
+    }
+
+    protected abstract void prepareAudioRtp(boolean isStereo, int sampleRate);
+
+    /**
+     * Call this method before use @startStream. If not you will do a stream without audio.
+     *
+     * @param bitrate         AAC in kb.
+     * @param sampleRate      of audio in hz. Can be 8000, 16000, 22500, 32000, 44100.
+     * @param isStereo        true if you want Stereo audio (2 audio channels), false if you want Mono audio
+     *                        (1 audio channel).
+     * @param echoCanceler    true enable echo canceler, false disable.
+     * @param noiseSuppressor true enable noise suppressor, false  disable.
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a AAC encoder).
+     */
+    public boolean prepareAudio(int audioSource, int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
+                                boolean noiseSuppressor) {
+        if (!microphoneManager.createMicrophone(audioSource, sampleRate, isStereo, echoCanceler, noiseSuppressor)) {
+            return false;
+        }
+        prepareAudioRtp(isStereo, sampleRate);
+        audioInitialized = audioEncoder.prepareAudioEncoder(bitrate, sampleRate, isStereo,
+                microphoneManager.getMaxInputSize());
+        return audioInitialized;
+    }
+
+    public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
+                                boolean noiseSuppressor) {
+        return prepareAudio(MediaRecorder.AudioSource.DEFAULT, bitrate, sampleRate, isStereo, echoCanceler,
+                noiseSuppressor);
+    }
+
+    public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo) {
+        return prepareAudio(bitrate, sampleRate, isStereo, false, false);
+    }
+
+    /**
+     * Same to call: isHardwareRotation = true; if (openGlVIew) isHardwareRotation = false;
+     * prepareVideo(640, 480, 30, 1200 * 1024, isHardwareRotation, 90);
+     *
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a H264 encoder).
+     */
+    public boolean prepareVideo() {
+        int rotation = CameraHelper.getCameraOrientation(context);
+        return prepareVideo(640, 480, 30, 1200 * 1024, rotation);
+    }
+
+    /**
+     * Same to call: prepareAudio(64 * 1024, 32000, true, false, false);
+     *
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a AAC encoder).
+     */
+    public boolean prepareAudio() {
+        return prepareAudio(64 * 1024, 32000, true, false, false);
+    }
+
+    /**
+     * @param codecTypeVideo force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
+     * @param codecTypeAudio force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
+     */
+    public void forceCodecType(CodecUtil.CodecType codecTypeVideo, CodecUtil.CodecType codecTypeAudio) {
+        videoEncoder.forceCodecType(codecTypeVideo);
+        audioEncoder.forceCodecType(codecTypeAudio);
+    }
+
+    /**
+     * Starts recording a MP4 video.
+     *
+     * @param path Where file will be saved.
+     * @throws IOException If initialized before a stream.
+     */
+    public void startRecord(@NonNull String path, @Nullable RecordController.Listener listener)
+            throws IOException {
+        recordController.startRecord(path, listener);
+        if (!streaming) {
+            startEncoders();
+        } else if (videoEncoder.isRunning()) {
+            requestKeyFrame();
+        }
+    }
+
+    public void startRecord(@NonNull final String path) throws IOException {
+        startRecord(path, null);
+    }
+
+    /**
+     * Starts recording a MP4 video.
+     *
+     * @param fd Where the file will be saved.
+     * @throws IOException If initialized before a stream.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void startRecord(@NonNull final FileDescriptor fd,
+                            @Nullable RecordController.Listener listener) throws IOException {
+        recordController.startRecord(fd, listener);
+        if (!streaming) {
+            startEncoders();
+        } else if (videoEncoder.isRunning()) {
+            requestKeyFrame();
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void startRecord(@NonNull final FileDescriptor fd) throws IOException {
+        startRecord(fd, null);
+    }
+
+    /**
+     * Stop record MP4 video started with @startRecord. If you don't call it file will be unreadable.
+     */
+    public void stopRecord() {
+        recordController.stopRecord();
+        if (!streaming) stopStream();
+    }
+
+    public void replaceView(Context context) {
+        isBackground = true;
+        replaceGlInterface(new GlStreamInterface(context));
+    }
+
+    public void replaceView(OpenGlView openGlView) {
+        isBackground = false;
+        replaceGlInterface(openGlView);
+    }
+
+    /**
+     * Replace glInterface used on fly. Ignored if you use SurfaceView, TextureView or context without
+     * OpenGl.
+     */
+    private void replaceGlInterface(GlInterface glInterface) {
+        if (this.glInterface != null && Build.VERSION.SDK_INT >= 18) {
+            if (isStreaming() || isRecording() || isOnPreview()) {
+                Point size = this.glInterface.getEncoderSize();
+                cameraManager.closeCamera();
+                this.glInterface.removeMediaCodecSurface();
+                this.glInterface.stop();
+                this.glInterface = glInterface;
+                this.glInterface.setEncoderSize(size.x, size.y);
+                this.glInterface.setRotation(videoEncoder.getRotation() == 0 ? 270 : videoEncoder.getRotation() - 90);
+                this.glInterface.start();
+                if (isStreaming() || isRecording()) {
+                    this.glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
+                }
+                cameraManager.prepareCamera(this.glInterface.getSurfaceTexture(), videoEncoder.getWidth(),
+                        videoEncoder.getHeight(), videoEncoder.getFps());
+                cameraManager.openLastCamera();
+            } else {
+                this.glInterface = glInterface;
+            }
+        }
+    }
+
+    /**
+     * Start camera preview. Ignored, if stream or preview is started.
+     *
+     * @param cameraFacing front or back camera. Like: {@link com.pedro.encoder.input.video.CameraHelper.Facing#BACK}
+     *                     {@link com.pedro.encoder.input.video.CameraHelper.Facing#FRONT}
+     * @param rotation     camera rotation (0, 90, 180, 270). Recommended: {@link
+     *                     com.pedro.encoder.input.video.CameraHelper#getCameraOrientation(Context)}
+     */
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int fps, int rotation) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing), width, height, fps, rotation);
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int rotation) {
+        startPreview(cameraFacing, width, height, videoEncoder.getFps(), rotation);
+    }
+
+    public void startPreview(String cameraId, int width, int height, int rotation) {
+        startPreview(cameraId, width, height, videoEncoder.getFps(), rotation);
+    }
+
+    public void startPreview(String cameraId, int width, int height, int fps, int rotation) {
+        if (!isStreaming() && !onPreview && !isBackground) {
+            previewWidth = width;
+            previewHeight = height;
+            videoEncoder.setFps(fps);
+            videoEncoder.setRotation(rotation);
+            if (surfaceView != null) {
+                cameraManager.prepareCamera(surfaceView.getHolder().getSurface(), videoEncoder.getFps());
+            } else if (textureView != null) {
+                cameraManager.prepareCamera(new Surface(textureView.getSurfaceTexture()),
+                        videoEncoder.getFps());
+            } else if (glInterface != null) {
+                if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
+                    glInterface.setEncoderSize(height, width);
+                } else {
+                    glInterface.setEncoderSize(width, height);
+                }
+                glInterface.setRotation(rotation == 0 ? 270 : rotation - 90);
+                glInterface.start();
+                cameraManager.prepareCamera(glInterface.getSurfaceTexture(), width, height,
+                        videoEncoder.getFps(), cameraId);
+            }
+            cameraManager.openCameraId(cameraId);
+            onPreview = true;
+        } else if (!isStreaming() && !onPreview && isBackground) {
+            // if you are using background mode startPreview only work to indicate
+            // that you want start with front or back camera
+            cameraManager.setCameraId(cameraId);
+        } else {
+            Log.e(TAG, "Streaming or preview started, ignored");
+        }
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                width, height, CameraHelper.getCameraOrientation(context));
+    }
+
+    public void startPreview(String cameraId, int width, int height) {
+        startPreview(cameraId, width, height, CameraHelper.getCameraOrientation(context));
+    }
+
+    public void startPreview(String cameraId, int rotation) {
+        startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int rotation) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
+    }
+
+    public void startPreview(String cameraId) {
+        startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight());
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                videoEncoder.getWidth(), videoEncoder.getHeight());
+    }
+
+    public void startPreview(int width, int height) {
+        startPreview(getCameraFacing(), width, height);
+    }
+
+    public void startPreview() {
+        startPreview(getCameraFacing());
+    }
+
+    /**
+     * Stop camera preview. Ignored if streaming or already stopped. You need call it after
+     *
+     * @stopStream to release camera properly if you will close activity.
+     */
+    public void stopPreview() {
+        if (!isStreaming() && !isRecording() && onPreview && !isBackground) {
+            if (glInterface != null) {
+                glInterface.stop();
+            }
+            cameraManager.closeCamera();
+            onPreview = false;
+            previewWidth = 0;
+            previewHeight = 0;
+        } else {
+            Log.e(TAG, "Streaming or preview stopped, ignored");
+        }
+    }
+
+    public void startStreamAndRecord(String url, String path, RecordController.Listener listener) throws IOException {
+        startStream(url);
+        recordController.startRecord(path, listener);
+    }
+
+    public void startStreamAndRecord(String url, String path) throws IOException {
+        startStreamAndRecord(url, path, null);
+    }
+
+    protected abstract void startStreamRtp(String url);
+
+    /**
+     * Need be called after @prepareVideo or/and @prepareAudio. This method override resolution of
+     *
+     * @param url of the stream like: protocol://ip:port/application/streamName
+     *            <p>
+     *            RTSP: rtsp://192.168.1.1:1935/live/pedroSG94 RTSPS: rtsps://192.168.1.1:1935/live/pedroSG94
+     *            RTMP: rtmp://192.168.1.1:1935/live/pedroSG94 RTMPS: rtmps://192.168.1.1:1935/live/pedroSG94
+     * @startPreview to resolution seated in @prepareVideo. If you never startPreview this method
+     * startPreview for you to resolution seated in @prepareVideo.
+     */
+    public void startStream(String url) {
+        streaming = true;
+        if (!recordController.isRunning()) {
+            startEncoders();
+        } else {
+            requestKeyFrame();
+        }
+        startStreamRtp(url);
+        onPreview = true;
+    }
+
+    private void startEncoders() {
+        videoEncoder.start();
+        if (audioInitialized) audioEncoder.start();
+        prepareGlView();
+        if (audioInitialized) microphoneManager.start();
+        if (glInterface == null && !cameraManager.isRunning() && videoEncoder.getWidth() != previewWidth
+                || videoEncoder.getHeight() != previewHeight) {
+            cameraManager.openLastCamera();
+        }
+        onPreview = true;
+    }
+
+    public void requestKeyFrame() {
+        if (videoEncoder.isRunning()) {
+            videoEncoder.requestKeyframe();
+        }
+    }
+
+    private void prepareGlView() {
+        if (glInterface != null) {
+            if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
+                glInterface.setEncoderSize(videoEncoder.getHeight(), videoEncoder.getWidth());
+            } else {
+                glInterface.setEncoderSize(videoEncoder.getWidth(), videoEncoder.getHeight());
+            }
+            int rotation = videoEncoder.getRotation();
+            glInterface.setRotation(rotation == 0 ? 270 : rotation - 90);
+            if (!cameraManager.isRunning() && videoEncoder.getWidth() != previewWidth
+                    || videoEncoder.getHeight() != previewHeight) {
+                glInterface.start();
+            }
+            if (videoEncoder.getInputSurface() != null) {
+                glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
+            }
+            cameraManager.prepareCamera(glInterface.getSurfaceTexture(), videoEncoder.getWidth(),
+                    videoEncoder.getHeight(), videoEncoder.getFps());
+        }
+    }
+
+    protected abstract void stopStreamRtp();
+
+    /**
+     * Stop stream started with @startStream.
+     */
+    public void stopStream() {
+        if (streaming) {
+            streaming = false;
+            stopStreamRtp();
+        }
+        if (!recordController.isRecording()) {
+            onPreview = !isBackground;
+            if (audioInitialized) microphoneManager.stop();
+            if (glInterface != null) {
+                glInterface.removeMediaCodecSurface();
+                if (glInterface instanceof GlStreamInterface) {
+                    glInterface.stop();
+                    cameraManager.closeCamera();
+                }
+            } else {
+                if (isBackground) {
+                    cameraManager.closeCamera();
+                    onPreview = false;
+                } else {
+                    cameraManager.stopRepeatingEncoder();
+                }
+            }
+            videoEncoder.stop();
+            if (audioInitialized) audioEncoder.stop();
+            recordController.resetFormats();
+        }
+    }
+
+    /**
+     * Get supported resolutions of back camera in px.
+     *
+     * @return list of resolutions supported by back camera
+     */
+    public List<Size> getResolutionsBack() {
+        return Arrays.asList(cameraManager.getCameraResolutionsBack());
+    }
+
+    /**
+     * Get supported resolutions of front camera in px.
+     *
+     * @return list of resolutions supported by front camera
+     */
+    public List<Size> getResolutionsFront() {
+        return Arrays.asList(cameraManager.getCameraResolutionsFront());
+    }
+
+    /**
+     * Get supported resolutions of cameraId in px.
+     *
+     * @return list of resolutions supported by cameraId
+     */
+    public List<Size> getResolutions(String cameraId) {
+        return Arrays.asList(cameraManager.getCameraResolutions(cameraId));
+    }
+
+    public List<Range<Integer>> getSupportedFps() {
+        return cameraManager.getSupportedFps(null, CameraHelper.Facing.BACK);
+    }
+
+    public List<Range<Integer>> getSupportedFps(Size size, CameraHelper.Facing facing) {
+        return cameraManager.getSupportedFps(size, facing);
+    }
+
+    /**
+     * Get supported properties of the camera
+     *
+     * @return CameraCharacteristics object
+     */
+    public CameraCharacteristics getCameraCharacteristics() {
+        return cameraManager.getCameraCharacteristics();
+    }
+
+    /**
+     * Set a custom size of audio buffer input.
+     * If you set 0 or less you can disable it to use library default value.
+     * Must be called before of prepareAudio method.
+     *
+     * @param size in bytes. Recommended multiple of 1024 (2048, 4096, 8196, etc)
+     */
+    public void setAudioMaxInputSize(int size) {
+        microphoneManager.setMaxInputSize(size);
+    }
+
+    /**
+     * Mute microphone, can be called before, while and after stream.
+     */
+    public void disableAudio() {
+        microphoneManager.mute();
+    }
+
+    /**
+     * Enable a muted microphone, can be called before, while and after stream.
+     */
+    public void enableAudio() {
+        microphoneManager.unMute();
+    }
+
+    /**
+     * Get mute state of microphone.
+     *
+     * @return true if muted, false if enabled
+     */
+    public boolean isAudioMuted() {
+        return microphoneManager.isMuted();
+    }
+
+    /**
+     * Return zoom level range
+     *
+     * @return zoom level range
+     */
+    public Range<Float> getZoomRange() {
+        return cameraManager.getZoomRange();
+    }
+
+    /**
+     * Return current zoom level
+     *
+     * @return current zoom level
+     */
+    public float getZoom() {
+        return cameraManager.getZoom();
+    }
+
+    /**
+     * Set zoomIn or zoomOut to camera.
+     * Use this method if you use a zoom slider.
+     *
+     * @param level Expected to be >= 1 and <= max zoom level
+     * @see Camera2Base#getZoom()
+     */
+    public void setZoom(float level) {
+        cameraManager.setZoom(level);
+    }
+
+    /**
+     * Set zoomIn or zoomOut to camera.
+     *
+     * @param event motion event. Expected to get event.getPointerCount() > 1
+     */
+    public void setZoom(MotionEvent event) {
+        cameraManager.setZoom(event);
+    }
+
+    /**
+     * @return optical zoom values available
+     * @Experimental
+     */
+    public float[] getOpticalZooms() {
+        return cameraManager.getOpticalZooms();
+    }
+
+    /**
+     * @param level value provided by getOpticalZooms method
+     * @Experimental
+     */
+    public void setOpticalZoom(float level) {
+        cameraManager.setOpticalZoom(level);
+    }
+
+    public int getBitrate() {
+        return videoEncoder.getBitRate();
+    }
+
+    public int getResolutionValue() {
+        return videoEncoder.getWidth() * videoEncoder.getHeight();
+    }
+
+    public int getStreamWidth() {
+        return videoEncoder.getWidth();
+    }
+
+    public int getStreamHeight() {
+        return videoEncoder.getHeight();
+    }
+
+    /**
+     * @return IDs of cameras available that can be used on startPreview of switchCamera. null If no cameras available
+     */
+    public String[] getCamerasAvailable() {
+        return cameraManager.getCamerasAvailable();
+    }
+
+    /**
+     * Switch camera used. Can be called anytime
+     *
+     * @throws CameraOpenException If the other camera doesn't support same resolution.
+     */
+    public void switchCamera() throws CameraOpenException {
+        if (isStreaming() || isRecording() || onPreview) {
+            cameraManager.switchCamera();
+        } else {
+            cameraManager.setCameraFacing(getCameraFacing() == CameraHelper.Facing.FRONT ? CameraHelper.Facing.BACK : CameraHelper.Facing.FRONT);
+        }
+    }
+
+    /**
+     * Choose a specific camera to use. Can be called anytime.
+     *
+     * @param cameraId Identifier of the camera to use.
+     * @throws CameraOpenException
+     */
+    public void switchCamera(String cameraId) throws CameraOpenException {
+        if (isStreaming() || onPreview) {
+            cameraManager.reOpenCamera(cameraId);
+        } else {
+            cameraManager.setCameraId(cameraId);
+        }
+    }
+
+    public void setExposure(int value) {
+        cameraManager.setExposure(value);
+    }
+
+    public int getExposure() {
+        return cameraManager.getExposure();
+    }
+
+    public int getMaxExposure() {
+        return cameraManager.getMaxExposure();
+    }
+
+    public int getMinExposure() {
+        return cameraManager.getMinExposure();
+    }
+
+    public void tapToFocus(View view, MotionEvent event) {
+        cameraManager.tapToFocus(view, event);
+    }
+
+    public GlInterface getGlInterface() {
+        if (glInterface != null) {
+            return glInterface;
+        } else {
+            throw new RuntimeException("You can't do it. You are not using Opengl");
+        }
+    }
+
+    private void prepareCameraManager() {
+        if (textureView != null) {
+            cameraManager.prepareCamera(textureView, videoEncoder.getInputSurface(),
+                    videoEncoder.getFps());
+        } else if (surfaceView != null) {
+            cameraManager.prepareCamera(surfaceView, videoEncoder.getInputSurface(),
+                    videoEncoder.getFps());
+        } else if (glInterface != null) {
+        } else {
+            cameraManager.prepareCamera(videoEncoder.getInputSurface(), videoEncoder.getFps());
+        }
+    }
+
+    /**
+     * Set video bitrate of H264 in bits per second while stream.
+     *
+     * @param bitrate H264 in bits per second.
+     */
+    public void setVideoBitrateOnFly(int bitrate) {
+        videoEncoder.setVideoBitrateOnFly(bitrate);
+    }
+
+    /**
+     * Force stream to work with fps selected in prepareVideo method. Must be called before prepareVideo.
+     * This is not recommend because could produce fps problems.
+     *
+     * @param enabled true to enabled, false to disable, disabled by default.
+     */
+    public void forceFpsLimit(boolean enabled) {
+        int fps = enabled ? videoEncoder.getFps() : 0;
+        videoEncoder.setForceFps(fps);
+        if (glInterface != null) glInterface.forceFpsLimit(fps);
+    }
+
+    /**
+     * Get stream state.
+     *
+     * @return true if streaming, false if not streaming.
+     */
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+    /**
+     * Get record state.
+     *
+     * @return true if recording, false if not recoding.
+     */
+    public boolean isRecording() {
+        return recordController.isRunning();
+    }
+
+    public void pauseRecord() {
+        recordController.pauseRecord();
+    }
+
+    public void resumeRecord() {
+        recordController.resumeRecord();
+    }
+
+    public RecordController.Status getRecordStatus() {
+        return recordController.getStatus();
+    }
+
+    public void addImageListener(int width, int height, int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
+        cameraManager.addImageListener(width, height, format, maxImages, true, listener);
+    }
+
+    public void addImageListener(int width, int height, int format, int maxImages, boolean autoClose, Camera2ApiManager.ImageCallback listener) {
+        cameraManager.addImageListener(width, height, format, maxImages, autoClose, listener);
+    }
+
+    public void addImageListener(int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
         if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
-          glInterface.setEncoderSize(height, width);
+            addImageListener(videoEncoder.getHeight(), videoEncoder.getWidth(), format, maxImages, listener);
         } else {
-          glInterface.setEncoderSize(width, height);
+            addImageListener(videoEncoder.getWidth(), videoEncoder.getHeight(), format, maxImages, listener);
         }
-        glInterface.setRotation(rotation == 0 ? 270 : rotation - 90);
-        glInterface.start();
-        cameraManager.prepareCamera(glInterface.getSurfaceTexture(), width, height,
-            videoEncoder.getFps(), cameraId);
-      }
-      cameraManager.openCameraId(cameraId);
-      onPreview = true;
-    } else if (!isStreaming() && !onPreview && isBackground) {
-      // if you are using background mode startPreview only work to indicate
-      // that you want start with front or back camera
-      cameraManager.setCameraId(cameraId);
-    } else {
-      Log.e(TAG, "Streaming or preview started, ignored");
-    }
-  }
-
-  public void startPreview(CameraHelper.Facing cameraFacing, int width, int height) {
-    startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
-            width, height, CameraHelper.getCameraOrientation(context));
-  }
-
-  public void startPreview(String cameraId, int width, int height) {
-    startPreview(cameraId, width, height, CameraHelper.getCameraOrientation(context));
-  }
-
-  public void startPreview(String cameraId, int rotation) {
-    startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
-  }
-
-  public void startPreview(CameraHelper.Facing cameraFacing, int rotation) {
-    startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
-            videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
-  }
-
-  public void startPreview(String cameraId) {
-    startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight());
-  }
-
-  public void startPreview(CameraHelper.Facing cameraFacing) {
-    startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
-            videoEncoder.getWidth(), videoEncoder.getHeight());
-  }
-
-  public void startPreview(int width, int height) {
-    startPreview(getCameraFacing(), width, height);
-  }
-
-  public void startPreview() {
-    startPreview(getCameraFacing());
-  }
-
-  /**
-   * Stop camera preview. Ignored if streaming or already stopped. You need call it after
-   *
-   * @stopStream to release camera properly if you will close activity.
-   */
-  public void stopPreview() {
-    if (!isStreaming() && !isRecording() && onPreview && !isBackground) {
-      if (glInterface != null) {
-        glInterface.stop();
-      }
-      cameraManager.closeCamera();
-      onPreview = false;
-      previewWidth = 0;
-      previewHeight = 0;
-    } else {
-      Log.e(TAG, "Streaming or preview stopped, ignored");
-    }
-  }
-
-  public void startStreamAndRecord(String url, String path, RecordController.Listener listener) throws IOException {
-    startStream(url);
-    recordController.startRecord(path, listener);
-  }
-
-  public void startStreamAndRecord(String url, String path) throws IOException {
-    startStreamAndRecord(url, path, null);
-  }
-
-  protected abstract void startStreamRtp(String url);
-
-  /**
-   * Need be called after @prepareVideo or/and @prepareAudio. This method override resolution of
-   *
-   * @param url of the stream like: protocol://ip:port/application/streamName
-   *
-   * RTSP: rtsp://192.168.1.1:1935/live/pedroSG94 RTSPS: rtsps://192.168.1.1:1935/live/pedroSG94
-   * RTMP: rtmp://192.168.1.1:1935/live/pedroSG94 RTMPS: rtmps://192.168.1.1:1935/live/pedroSG94
-   * @startPreview to resolution seated in @prepareVideo. If you never startPreview this method
-   * startPreview for you to resolution seated in @prepareVideo.
-   */
-  public void startStream(String url) {
-    streaming = true;
-    if (!recordController.isRunning()) {
-      startEncoders();
-    } else {
-      requestKeyFrame();
-    }
-    startStreamRtp(url);
-    onPreview = true;
-  }
-
-  private void startEncoders() {
-    videoEncoder.start();
-    if (audioInitialized) audioEncoder.start();
-    prepareGlView();
-    if (audioInitialized) microphoneManager.start();
-    if (glInterface == null && !cameraManager.isRunning() && videoEncoder.getWidth() != previewWidth
-        || videoEncoder.getHeight() != previewHeight) {
-      cameraManager.openLastCamera();
-    }
-    onPreview = true;
-  }
-
-  public void requestKeyFrame() {
-    if (videoEncoder.isRunning()) {
-      videoEncoder.requestKeyframe();
-    }
-  }
-
-  private void prepareGlView() {
-    if (glInterface != null) {
-      if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
-        glInterface.setEncoderSize(videoEncoder.getHeight(), videoEncoder.getWidth());
-      } else {
-        glInterface.setEncoderSize(videoEncoder.getWidth(), videoEncoder.getHeight());
-      }
-      int rotation = videoEncoder.getRotation();
-      glInterface.setRotation(rotation == 0 ? 270 : rotation - 90);
-      if (!cameraManager.isRunning() && videoEncoder.getWidth() != previewWidth
-          || videoEncoder.getHeight() != previewHeight) {
-        glInterface.start();
-      }
-      if (videoEncoder.getInputSurface() != null) {
-        glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
-      }
-      cameraManager.prepareCamera(glInterface.getSurfaceTexture(), videoEncoder.getWidth(),
-          videoEncoder.getHeight(), videoEncoder.getFps());
-    }
-  }
-
-  protected abstract void stopStreamRtp();
-
-  /**
-   * Stop stream started with @startStream.
-   */
-  public void stopStream() {
-    if (streaming) {
-      streaming = false;
-      stopStreamRtp();
-    }
-    if (!recordController.isRecording()) {
-      onPreview = !isBackground;
-      if (audioInitialized) microphoneManager.stop();
-      if (glInterface != null) {
-        glInterface.removeMediaCodecSurface();
-        if (glInterface instanceof GlStreamInterface) {
-          glInterface.stop();
-          cameraManager.closeCamera();
-        }
-      } else {
-        if (isBackground) {
-          cameraManager.closeCamera();
-          onPreview = false;
-        } else {
-          cameraManager.stopRepeatingEncoder();
-        }
-      }
-      videoEncoder.stop();
-      if (audioInitialized) audioEncoder.stop();
-      recordController.resetFormats();
-    }
-  }
-
-  /**
-   * Get supported resolutions of back camera in px.
-   *
-   * @return list of resolutions supported by back camera
-   */
-  public List<Size> getResolutionsBack() {
-    return Arrays.asList(cameraManager.getCameraResolutionsBack());
-  }
-
-  /**
-   * Get supported resolutions of front camera in px.
-   *
-   * @return list of resolutions supported by front camera
-   */
-  public List<Size> getResolutionsFront() {
-    return Arrays.asList(cameraManager.getCameraResolutionsFront());
-  }
-
-  /**
-   * Get supported resolutions of cameraId in px.
-   *
-   * @return list of resolutions supported by cameraId
-   */
-  public List<Size> getResolutions(String cameraId) {
-    return Arrays.asList(cameraManager.getCameraResolutions(cameraId));
-  }
-
-  public List<Range<Integer>> getSupportedFps() {
-    return cameraManager.getSupportedFps(null, CameraHelper.Facing.BACK);
-  }
-
-  public List<Range<Integer>> getSupportedFps(Size size, CameraHelper.Facing facing) {
-    return cameraManager.getSupportedFps(size, facing);
-  }
-
-  /**
-   * Get supported properties of the camera
-   *
-   * @return CameraCharacteristics object
-   */
-  public CameraCharacteristics getCameraCharacteristics() {
-    return cameraManager.getCameraCharacteristics();
-  }
-
-  /**
-   * Set a custom size of audio buffer input.
-   * If you set 0 or less you can disable it to use library default value.
-   * Must be called before of prepareAudio method.
-   *
-   * @param size in bytes. Recommended multiple of 1024 (2048, 4096, 8196, etc)
-   */
-  public void setAudioMaxInputSize(int size) {
-    microphoneManager.setMaxInputSize(size);
-  }
-
-  /**
-   * Mute microphone, can be called before, while and after stream.
-   */
-  public void disableAudio() {
-    microphoneManager.mute();
-  }
-
-  /**
-   * Enable a muted microphone, can be called before, while and after stream.
-   */
-  public void enableAudio() {
-    microphoneManager.unMute();
-  }
-
-  /**
-   * Get mute state of microphone.
-   *
-   * @return true if muted, false if enabled
-   */
-  public boolean isAudioMuted() {
-    return microphoneManager.isMuted();
-  }
-
-  /**
-   * Return zoom level range
-   *
-   * @return zoom level range
-   */
-  public Range<Float> getZoomRange() {
-    return cameraManager.getZoomRange();
-  }
-
-  /**
-   * Return current zoom level
-   *
-   * @return current zoom level
-   */
-  public float getZoom() {
-    return cameraManager.getZoom();
-  }
-
-  /**
-   * Set zoomIn or zoomOut to camera.
-   * Use this method if you use a zoom slider.
-   *
-   * @param level Expected to be >= 1 and <= max zoom level
-   * @see Camera2Base#getZoom()
-   */
-  public void setZoom(float level) {
-    cameraManager.setZoom(level);
-  }
-
-  /**
-   * Set zoomIn or zoomOut to camera.
-   *
-   * @param event motion event. Expected to get event.getPointerCount() > 1
-   */
-  public void setZoom(MotionEvent event) {
-    cameraManager.setZoom(event);
-  }
-
-  /**
-   * @Experimental
-   * @return optical zoom values available
-   */
-  public float[] getOpticalZooms() {
-    return cameraManager.getOpticalZooms();
-  }
-
-  /**
-   * @Experimental
-   * @param level value provided by getOpticalZooms method
-   */
-  public void setOpticalZoom(float level) {
-    cameraManager.setOpticalZoom(level);
-  }
-
-  public int getBitrate() {
-    return videoEncoder.getBitRate();
-  }
-
-  public int getResolutionValue() {
-    return videoEncoder.getWidth() * videoEncoder.getHeight();
-  }
-
-  public int getStreamWidth() {
-    return videoEncoder.getWidth();
-  }
-
-  public int getStreamHeight() {
-    return videoEncoder.getHeight();
-  }
-
-  /**
-   * @return IDs of cameras available that can be used on startPreview of switchCamera. null If no cameras available
-   */
-  public String[] getCamerasAvailable() {
-    return cameraManager.getCamerasAvailable();
-  }
-  /**
-   * Switch camera used. Can be called anytime
-   *
-   * @throws CameraOpenException If the other camera doesn't support same resolution.
-   */
-  public void switchCamera() throws CameraOpenException {
-    if (isStreaming() || isRecording() || onPreview) {
-      cameraManager.switchCamera();
-    } else {
-      cameraManager.setCameraFacing(getCameraFacing() == CameraHelper.Facing.FRONT ? CameraHelper.Facing.BACK : CameraHelper.Facing.FRONT);
-    }
-  }
-
-  /**
-   * Choose a specific camera to use. Can be called anytime.
-   *
-   * @param cameraId Identifier of the camera to use.
-   * @throws CameraOpenException
-   */
-  public void switchCamera(String cameraId) throws CameraOpenException {
-    if (isStreaming() || onPreview) {
-      cameraManager.reOpenCamera(cameraId);
-    } else {
-      cameraManager.setCameraId(cameraId);
-    }
-  }
-
-  public void setExposure(int value) {
-    cameraManager.setExposure(value);
-  }
-
-  public int getExposure() {
-    return cameraManager.getExposure();
-  }
-
-  public int getMaxExposure() {
-    return cameraManager.getMaxExposure();
-  }
-
-  public int getMinExposure() {
-    return cameraManager.getMinExposure();
-  }
-
-  public void tapToFocus(MotionEvent event) {
-    cameraManager.tapToFocus(event);
-  }
-
-  public GlInterface getGlInterface() {
-    if (glInterface != null) {
-      return glInterface;
-    } else {
-      throw new RuntimeException("You can't do it. You are not using Opengl");
-    }
-  }
-
-  private void prepareCameraManager() {
-    if (textureView != null) {
-      cameraManager.prepareCamera(textureView, videoEncoder.getInputSurface(),
-          videoEncoder.getFps());
-    } else if (surfaceView != null) {
-      cameraManager.prepareCamera(surfaceView, videoEncoder.getInputSurface(),
-          videoEncoder.getFps());
-    } else if (glInterface != null) {
-    } else {
-      cameraManager.prepareCamera(videoEncoder.getInputSurface(), videoEncoder.getFps());
-    }
-  }
-
-  /**
-   * Set video bitrate of H264 in bits per second while stream.
-   *
-   * @param bitrate H264 in bits per second.
-   */
-  public void setVideoBitrateOnFly(int bitrate) {
-    videoEncoder.setVideoBitrateOnFly(bitrate);
-  }
-
-  /**
-   * Force stream to work with fps selected in prepareVideo method. Must be called before prepareVideo.
-   * This is not recommend because could produce fps problems.
-   *
-   * @param enabled true to enabled, false to disable, disabled by default.
-   */
-  public void forceFpsLimit(boolean enabled) {
-    int fps = enabled ? videoEncoder.getFps() : 0;
-    videoEncoder.setForceFps(fps);
-    if (glInterface != null) glInterface.forceFpsLimit(fps);
-  }
-
-  /**
-   * Get stream state.
-   *
-   * @return true if streaming, false if not streaming.
-   */
-  public boolean isStreaming() {
-    return streaming;
-  }
-
-  /**
-   * Get record state.
-   *
-   * @return true if recording, false if not recoding.
-   */
-  public boolean isRecording() {
-    return recordController.isRunning();
-  }
-
-  public void pauseRecord() {
-    recordController.pauseRecord();
-  }
-
-  public void resumeRecord() {
-    recordController.resumeRecord();
-  }
-
-  public RecordController.Status getRecordStatus() {
-    return recordController.getStatus();
-  }
-
-  public void addImageListener(int width, int height, int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
-    cameraManager.addImageListener(width, height, format, maxImages, true, listener);
-  }
-
-  public void addImageListener(int width, int height, int format, int maxImages, boolean autoClose, Camera2ApiManager.ImageCallback listener) {
-    cameraManager.addImageListener(width, height, format, maxImages, autoClose, listener);
-  }
-
-  public void addImageListener(int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
-    if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
-      addImageListener(videoEncoder.getHeight(), videoEncoder.getWidth(), format, maxImages, listener);
-    } else {
-      addImageListener(videoEncoder.getWidth(), videoEncoder.getHeight(), format, maxImages, listener);
-    }
-  }
-
-  public void removeImageListener() {
-    cameraManager.removeImageListener();
-  }
-  /**
-   * Get preview state.
-   *
-   * @return true if enabled, false if disabled.
-   */
-  public boolean isOnPreview() {
-    return onPreview;
-  }
-
-  protected abstract void getAacDataRtp(ByteBuffer aacBuffer, MediaCodec.BufferInfo info);
-
-  protected abstract void onSpsPpsVpsRtp(ByteBuffer sps, ByteBuffer pps, ByteBuffer vps);
-
-  protected abstract void getH264DataRtp(ByteBuffer h264Buffer, MediaCodec.BufferInfo info);
-
-  public void setRecordController(BaseRecordController recordController) {
-    if (!isRecording()) this.recordController = recordController;
-  }
-
-  private final GetMicrophoneData getMicrophoneData = frame -> {
-    audioEncoder.inputPCMData(frame);
-  };
-
-  private final GetAacData getAacData = new GetAacData() {
-    @Override
-    public void getAacData(@NonNull ByteBuffer aacBuffer, @NonNull MediaCodec.BufferInfo info) {
-      recordController.recordAudio(aacBuffer, info);
-      if (streaming) getAacDataRtp(aacBuffer, info);
     }
 
-    @Override
-    public void onAudioFormat(@NonNull MediaFormat mediaFormat) {
-      recordController.setAudioFormat(mediaFormat);
-    }
-  };
-
-  private final GetVideoData getVideoData = new GetVideoData() {
-    @Override
-    public void onSpsPpsVps(@NonNull ByteBuffer sps, @Nullable ByteBuffer pps, @Nullable ByteBuffer vps) {
-      onSpsPpsVpsRtp(sps.duplicate(),  pps != null ? pps.duplicate(): null, vps != null ? vps.duplicate() : null);
+    public void removeImageListener() {
+        cameraManager.removeImageListener();
     }
 
-    @Override
-    public void getVideoData(@NonNull ByteBuffer h264Buffer, @NonNull MediaCodec.BufferInfo info) {
-      fpsListener.calculateFps();
-      recordController.recordVideo(h264Buffer, info);
-      if (streaming) getH264DataRtp(h264Buffer, info);
+    /**
+     * Get preview state.
+     *
+     * @return true if enabled, false if disabled.
+     */
+    public boolean isOnPreview() {
+        return onPreview;
     }
 
-    @Override
-    public void onVideoFormat(@NonNull MediaFormat mediaFormat) {
-      recordController.setVideoFormat(mediaFormat, !audioInitialized);
+    protected abstract void getAacDataRtp(ByteBuffer aacBuffer, MediaCodec.BufferInfo info);
+
+    protected abstract void onSpsPpsVpsRtp(ByteBuffer sps, ByteBuffer pps, ByteBuffer vps);
+
+    protected abstract void getH264DataRtp(ByteBuffer h264Buffer, MediaCodec.BufferInfo info);
+
+    public void setRecordController(BaseRecordController recordController) {
+        if (!isRecording()) this.recordController = recordController;
     }
-  };
 
-  public abstract StreamBaseClient getStreamClient();
-
-  public void setVideoCodec(VideoCodec codec) {
-    setVideoCodecImp(codec);
-    recordController.setVideoCodec(codec);
-    String type = switch (codec) {
-      case H264 -> CodecUtil.H264_MIME;
-      case H265 -> CodecUtil.H265_MIME;
-      case AV1 -> CodecUtil.AV1_MIME;
+    private final GetMicrophoneData getMicrophoneData = frame -> {
+        audioEncoder.inputPCMData(frame);
     };
-    videoEncoder.setType(type);
-  }
 
-  public void setAudioCodec(AudioCodec codec) {
-    setAudioCodecImp(codec);
-    recordController.setAudioCodec(codec);
-    String type = switch (codec) {
-      case G711 -> CodecUtil.G711_MIME;
-      case AAC -> CodecUtil.AAC_MIME;
-      case OPUS -> CodecUtil.OPUS_MIME;
+    private final GetAacData getAacData = new GetAacData() {
+        @Override
+        public void getAacData(@NonNull ByteBuffer aacBuffer, @NonNull MediaCodec.BufferInfo info) {
+            recordController.recordAudio(aacBuffer, info);
+            if (streaming) getAacDataRtp(aacBuffer, info);
+        }
+
+        @Override
+        public void onAudioFormat(@NonNull MediaFormat mediaFormat) {
+            recordController.setAudioFormat(mediaFormat);
+        }
     };
-    audioEncoder.setType(type);
-  }
 
-  protected abstract void setVideoCodecImp(VideoCodec codec);
-  protected abstract void setAudioCodecImp(AudioCodec codec);
+    private final GetVideoData getVideoData = new GetVideoData() {
+        @Override
+        public void onSpsPpsVps(@NonNull ByteBuffer sps, @Nullable ByteBuffer pps, @Nullable ByteBuffer vps) {
+            onSpsPpsVpsRtp(sps.duplicate(), pps != null ? pps.duplicate() : null, vps != null ? vps.duplicate() : null);
+        }
+
+        @Override
+        public void getVideoData(@NonNull ByteBuffer h264Buffer, @NonNull MediaCodec.BufferInfo info) {
+            fpsListener.calculateFps();
+            recordController.recordVideo(h264Buffer, info);
+            if (streaming) getH264DataRtp(h264Buffer, info);
+        }
+
+        @Override
+        public void onVideoFormat(@NonNull MediaFormat mediaFormat) {
+            recordController.setVideoFormat(mediaFormat, !audioInitialized);
+        }
+    };
+
+    public abstract StreamBaseClient getStreamClient();
+
+    public void setVideoCodec(VideoCodec codec) {
+        setVideoCodecImp(codec);
+        recordController.setVideoCodec(codec);
+        String type = switch (codec) {
+            case H264 -> CodecUtil.H264_MIME;
+            case H265 -> CodecUtil.H265_MIME;
+            case AV1 -> CodecUtil.AV1_MIME;
+        };
+        videoEncoder.setType(type);
+    }
+
+    public void setAudioCodec(AudioCodec codec) {
+        setAudioCodecImp(codec);
+        recordController.setAudioCodec(codec);
+        String type = switch (codec) {
+            case G711 -> CodecUtil.G711_MIME;
+            case AAC -> CodecUtil.AAC_MIME;
+            case OPUS -> CodecUtil.OPUS_MIME;
+        };
+        audioEncoder.setType(type);
+    }
+
+    protected abstract void setVideoCodecImp(VideoCodec codec);
+
+    protected abstract void setAudioCodecImp(AudioCodec codec);
 }


### PR DESCRIPTION
RootEncoder is nice to work with, but there is no demo app that uses the Android camera2 api, and if there were, the tap-to-focus feature would not be working on it. There were two main problems: passing the wrong flags when creating the metering rectangle, and not interpolating the point from view space to camera sensor space.

Unfortunately, Android Studio also reformatted the java. Fortunately I dont really care