### PR TITLE
Make so RootEncoder delivers bandwidth info needed for bitrate changing

### DIFF
--- a/app/src/main/java/com/pedro/streamer/file/FromFileActivity.kt
+++ b/app/src/main/java/com/pedro/streamer/file/FromFileActivity.kt
@@ -32,6 +32,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.pedro.common.ConnectChecker
+import com.pedro.common.Throughput
 import com.pedro.encoder.input.decoder.AudioDecoderInterface
 import com.pedro.encoder.input.decoder.VideoDecoderInterface
 import com.pedro.library.base.recording.RecordController
@@ -191,8 +192,13 @@ class FromFileActivity : AppCompatActivity(), ConnectChecker,
     if (!genericFromFile.isRecording) ScreenOrientation.unlockScreen(this)
   }
 
-  override fun onNewBitrate(bitrate: Long) {}
-
+  override fun onStreamingStats(
+    bitrate: Long,
+    bytesSent: Long,
+    bytesQueued: Long,
+    throughput: Throughput
+  ) {
+  }
   override fun onDisconnect() {
     toast("Disconnected")
   }

--- a/app/src/main/java/com/pedro/streamer/oldapi/OldApiActivity.kt
+++ b/app/src/main/java/com/pedro/streamer/oldapi/OldApiActivity.kt
@@ -25,6 +25,7 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.pedro.common.ConnectChecker
+import com.pedro.common.Throughput
 import com.pedro.encoder.input.video.CameraHelper
 import com.pedro.encoder.input.video.CameraOpenException
 import com.pedro.library.base.recording.RecordController
@@ -147,8 +148,13 @@ class OldApiActivity : AppCompatActivity(), ConnectChecker, TextureView.SurfaceT
     bStream.setImageResource(R.drawable.stream_icon)
   }
 
-  override fun onNewBitrate(bitrate: Long) {}
-
+  override fun onStreamingStats(
+    bitrate: Long,
+    bytesSent: Long,
+    bytesQueued: Long,
+    throughput: Throughput
+  ) {
+  }
   override fun onDisconnect() {
     toast("Disconnected")
   }

--- a/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
+++ b/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
@@ -29,6 +29,7 @@ import android.widget.ImageView
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import com.pedro.common.ConnectChecker
+import com.pedro.common.Throughput
 import com.pedro.library.base.recording.RecordController
 import com.pedro.library.generic.GenericStream
 import com.pedro.library.util.sources.video.Camera1Source
@@ -65,157 +66,167 @@ import java.util.Locale
  * [com.pedro.library.srt.SrtStream]
  */
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-class CameraFragment: Fragment(), ConnectChecker {
+class CameraFragment : Fragment(), ConnectChecker {
 
-  companion object {
-    fun getInstance(): CameraFragment = CameraFragment()
-  }
-
-  val genericStream: GenericStream by lazy {
-    GenericStream(requireContext(), this).apply {
-      getGlInterface().autoHandleOrientation = true
+    companion object {
+        fun getInstance(): CameraFragment = CameraFragment()
     }
-  }
-  private lateinit var surfaceView: SurfaceView
-  private lateinit var bStartStop: ImageView
-  private val width = 640
-  private val height = 480
-  private val vBitrate = 1200 * 1000
-  private var rotation = 0
-  private val sampleRate = 32000
-  private val isStereo = true
-  private val aBitrate = 128 * 1000
-  private var recordPath = ""
 
-  @SuppressLint("ClickableViewAccessibility")
-  override fun onCreateView(
-    inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-  ): View? {
-    val view = inflater.inflate(R.layout.fragment_camera, container, false)
-    bStartStop = view.findViewById(R.id.b_start_stop)
-    val bRecord = view.findViewById<ImageView>(R.id.b_record)
-    val bSwitchCamera = view.findViewById<ImageView>(R.id.switch_camera)
-    val etUrl = view.findViewById<EditText>(R.id.et_rtp_url)
-
-    surfaceView = view.findViewById(R.id.surfaceView)
-    (activity as? RotationActivity)?.let {
-      surfaceView.setOnTouchListener(it)
+    val genericStream: GenericStream by lazy {
+        GenericStream(requireContext(), this).apply {
+            getGlInterface().autoHandleOrientation = true
+        }
     }
-    surfaceView.holder.addCallback(object: SurfaceHolder.Callback {
-      override fun surfaceCreated(holder: SurfaceHolder) {
-        if (!genericStream.isOnPreview) genericStream.startPreview(surfaceView)
-      }
+    private lateinit var surfaceView: SurfaceView
+    private lateinit var bStartStop: ImageView
+    private val width = 640
+    private val height = 480
+    private val vBitrate = 1200 * 1000
+    private var rotation = 0
+    private val sampleRate = 32000
+    private val isStereo = true
+    private val aBitrate = 128 * 1000
+    private var recordPath = ""
 
-      override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-        genericStream.getGlInterface().setPreviewResolution(width, height)
-      }
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_camera, container, false)
+        bStartStop = view.findViewById(R.id.b_start_stop)
+        val bRecord = view.findViewById<ImageView>(R.id.b_record)
+        val bSwitchCamera = view.findViewById<ImageView>(R.id.switch_camera)
+        val etUrl = view.findViewById<EditText>(R.id.et_rtp_url)
 
-      override fun surfaceDestroyed(holder: SurfaceHolder) {
-        if (genericStream.isOnPreview) genericStream.stopPreview()
-      }
+        surfaceView = view.findViewById(R.id.surfaceView)
+        (activity as? RotationActivity)?.let {
+            surfaceView.setOnTouchListener(it)
+        }
+        surfaceView.holder.addCallback(object : SurfaceHolder.Callback {
+            override fun surfaceCreated(holder: SurfaceHolder) {
+                if (!genericStream.isOnPreview) genericStream.startPreview(surfaceView)
+            }
 
-    })
+            override fun surfaceChanged(
+                holder: SurfaceHolder,
+                format: Int,
+                width: Int,
+                height: Int
+            ) {
+                genericStream.getGlInterface().setPreviewResolution(width, height)
+            }
 
-    bStartStop.setOnClickListener {
-      if (!genericStream.isStreaming) {
-        genericStream.startStream(etUrl.text.toString())
-        bStartStop.setImageResource(R.drawable.stream_stop_icon)
-      } else {
+            override fun surfaceDestroyed(holder: SurfaceHolder) {
+                if (genericStream.isOnPreview) genericStream.stopPreview()
+            }
+
+        })
+
+        bStartStop.setOnClickListener {
+            if (!genericStream.isStreaming) {
+                genericStream.startStream(etUrl.text.toString())
+                bStartStop.setImageResource(R.drawable.stream_stop_icon)
+            } else {
+                genericStream.stopStream()
+                bStartStop.setImageResource(R.drawable.stream_icon)
+            }
+        }
+        bRecord.setOnClickListener {
+            if (!genericStream.isRecording) {
+                val folder = PathUtils.getRecordPath()
+                if (!folder.exists()) folder.mkdir()
+                val sdf = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault())
+                recordPath = "${folder.absolutePath}/${sdf.format(Date())}.mp4"
+                genericStream.startRecord(recordPath) { status ->
+                    if (status == RecordController.Status.RECORDING) {
+                        bRecord.setImageResource(R.drawable.stop_icon)
+                    }
+                }
+                bRecord.setImageResource(R.drawable.pause_icon)
+            } else {
+                genericStream.stopRecord()
+                bRecord.setImageResource(R.drawable.record_icon)
+                PathUtils.updateGallery(requireContext(), recordPath)
+            }
+        }
+        bSwitchCamera.setOnClickListener {
+            when (val source = genericStream.videoSource) {
+                is Camera1Source -> source.switchCamera()
+                is Camera2Source -> source.switchCamera()
+                is CameraXSource -> source.switchCamera()
+            }
+        }
+        return view
+    }
+
+    fun setOrientationMode(isVertical: Boolean) {
+        val wasOnPreview = genericStream.isOnPreview
+        genericStream.release()
+        rotation = if (isVertical) 90 else 0
+        prepare()
+        if (wasOnPreview) genericStream.startPreview(surfaceView)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        prepare()
+        genericStream.getStreamClient().setReTries(10)
+    }
+
+    private fun prepare() {
+        val prepared = try {
+            genericStream.prepareVideo(width, height, vBitrate, rotation = rotation) &&
+                    genericStream.prepareAudio(sampleRate, isStereo, aBitrate)
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+        if (!prepared) {
+            toast("Audio or Video configuration failed")
+            activity?.finish()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        genericStream.release()
+    }
+
+    override fun onConnectionStarted(url: String) {
+    }
+
+    override fun onConnectionSuccess() {
+        toast("Connected")
+    }
+
+    override fun onConnectionFailed(reason: String) {
+        if (genericStream.getStreamClient().reTry(5000, reason, null)) {
+            toast("Retry")
+        } else {
+            genericStream.stopStream()
+            bStartStop.setImageResource(R.drawable.stream_icon)
+            toast("Failed: $reason")
+        }
+    }
+
+    override fun onStreamingStats(
+        bitrate: Long,
+        bytesSent: Long,
+        bytesQueued: Long,
+        throughput: Throughput
+    ) {
+    }
+
+    override fun onDisconnect() {
+        toast("Disconnected")
+    }
+
+    override fun onAuthError() {
         genericStream.stopStream()
         bStartStop.setImageResource(R.drawable.stream_icon)
-      }
+        toast("Auth error")
     }
-    bRecord.setOnClickListener {
-      if (!genericStream.isRecording) {
-        val folder = PathUtils.getRecordPath()
-        if (!folder.exists()) folder.mkdir()
-        val sdf = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault())
-        recordPath = "${folder.absolutePath}/${sdf.format(Date())}.mp4"
-        genericStream.startRecord(recordPath) { status ->
-          if (status == RecordController.Status.RECORDING) {
-            bRecord.setImageResource(R.drawable.stop_icon)
-          }
-        }
-        bRecord.setImageResource(R.drawable.pause_icon)
-      } else {
-        genericStream.stopRecord()
-        bRecord.setImageResource(R.drawable.record_icon)
-        PathUtils.updateGallery(requireContext(), recordPath)
-      }
+
+    override fun onAuthSuccess() {
+        toast("Auth success")
     }
-    bSwitchCamera.setOnClickListener {
-      when (val source = genericStream.videoSource) {
-        is Camera1Source -> source.switchCamera()
-        is Camera2Source -> source.switchCamera()
-        is CameraXSource -> source.switchCamera()
-      }
-    }
-    return view
-  }
-
-  fun setOrientationMode(isVertical: Boolean) {
-    val wasOnPreview = genericStream.isOnPreview
-    genericStream.release()
-    rotation = if (isVertical) 90 else 0
-    prepare()
-    if (wasOnPreview) genericStream.startPreview(surfaceView)
-  }
-
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    prepare()
-    genericStream.getStreamClient().setReTries(10)
-  }
-
-  private fun prepare() {
-    val prepared = try {
-      genericStream.prepareVideo(width, height, vBitrate, rotation = rotation) &&
-          genericStream.prepareAudio(sampleRate, isStereo, aBitrate)
-    } catch (e: IllegalArgumentException) {
-      false
-    }
-    if (!prepared) {
-      toast("Audio or Video configuration failed")
-      activity?.finish()
-    }
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    genericStream.release()
-  }
-
-  override fun onConnectionStarted(url: String) {
-  }
-
-  override fun onConnectionSuccess() {
-    toast("Connected")
-  }
-
-  override fun onConnectionFailed(reason: String) {
-    if (genericStream.getStreamClient().reTry(5000, reason, null)) {
-      toast("Retry")
-    } else {
-      genericStream.stopStream()
-      bStartStop.setImageResource(R.drawable.stream_icon)
-      toast("Failed: $reason")
-    }
-  }
-
-  override fun onNewBitrate(bitrate: Long) {
-  }
-
-  override fun onDisconnect() {
-    toast("Disconnected")
-  }
-
-  override fun onAuthError() {
-    genericStream.stopStream()
-    bStartStop.setImageResource(R.drawable.stream_icon)
-    toast("Auth error")
-  }
-
-  override fun onAuthSuccess() {
-    toast("Auth success")
-  }
 }

--- a/app/src/main/java/com/pedro/streamer/screen/ScreenActivity.kt
+++ b/app/src/main/java/com/pedro/streamer/screen/ScreenActivity.kt
@@ -25,6 +25,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.pedro.common.ConnectChecker
+import com.pedro.common.Throughput
 import com.pedro.streamer.R
 import com.pedro.streamer.utils.toast
 
@@ -125,7 +126,13 @@ class ScreenActivity : AppCompatActivity(), ConnectChecker {
     toast("Failed: $reason")
   }
 
-  override fun onNewBitrate(bitrate: Long) {}
+  override fun onStreamingStats(
+    bitrate: Long,
+    bytesSent: Long,
+    bytesQueued: Long,
+    throughput: Throughput
+  ) {
+  }
   override fun onDisconnect() {
     toast("Disconnected")
   }

--- a/app/src/main/java/com/pedro/streamer/screen/ScreenService.kt
+++ b/app/src/main/java/com/pedro/streamer/screen/ScreenService.kt
@@ -28,6 +28,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import com.pedro.common.ConnectChecker
+import com.pedro.common.Throughput
 import com.pedro.library.generic.GenericStream
 import com.pedro.library.util.sources.audio.MicrophoneSource
 import com.pedro.library.util.sources.video.NoVideoSource
@@ -159,10 +160,14 @@ class ScreenService: Service(), ConnectChecker {
     callback?.onConnectionSuccess()
   }
 
-  override fun onNewBitrate(bitrate: Long) {
-    callback?.onNewBitrate(bitrate)
+  override fun onStreamingStats(
+    bitrate: Long,
+    bytesSent: Long,
+    bytesQueued: Long,
+    throughput: Throughput
+  ) {
+    callback?.onStreamingStats(bitrate, bytesSent, bytesQueued, throughput)
   }
-
   override fun onConnectionFailed(reason: String) {
     callback?.onConnectionFailed(reason)
   }

--- a/common/src/main/java/com/pedro/common/ConnectChecker.kt
+++ b/common/src/main/java/com/pedro/common/ConnectChecker.kt
@@ -16,6 +16,11 @@
 
 package com.pedro.common
 
+enum class Throughput {
+  Unknown,
+  Sufficient,
+  Insufficient
+}
 /**
  * Created by pedro on 21/08/23.
  */
@@ -23,7 +28,7 @@ interface ConnectChecker {
   fun onConnectionStarted(url: String)
   fun onConnectionSuccess()
   fun onConnectionFailed(reason: String)
-  fun onNewBitrate(bitrate: Long)
+  fun onStreamingStats(bitrate: Long, bytesSent: Long, bytesQueued:Long, throughput: Throughput)
   fun onDisconnect()
   fun onAuthError()
   fun onAuthSuccess()

--- a/common/src/test/java/com/pedro/common/BitrateManagerTest.kt
+++ b/common/src/test/java/com/pedro/common/BitrateManagerTest.kt
@@ -63,15 +63,15 @@ class BitrateManagerTest {
       val fakeValues = arrayOf(100L, 200L, 300L, 400L, 500L)
       var expectedResult = 0L
       fakeValues.forEach {
-        bitrateManager.calculateBitrate(it)
+        bitrateManager.calculateBandwidth(it)
         expectedResult += it
       }
       fakeTime += 1000
       val value = 100L
-      bitrateManager.calculateBitrate(value)
+      bitrateManager.calculateBandwidth(value)
       expectedResult += value
       val resultValue = argumentCaptor<Long>()
-      verify(connectChecker, times(1)).onNewBitrate(resultValue.capture())
+      verify(connectChecker, times(1)).onStreamingStats(resultValue.capture())
       val marginError = 20
       assertTrue(expectedResult - marginError <= resultValue.firstValue && resultValue.firstValue <= expectedResult + marginError)
     }

--- a/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspSender.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspSender.kt
@@ -162,7 +162,7 @@ class RtspSender(
       val bitrateTask = async {
         while (scope.isActive && running) {
           //bytes to bits
-          bitrateManager.calculateBitrate(bytesSend * 8)
+          bitrateManager.calculateBandwidth(bytesSend, 0)
           bytesSend = 0
           delay(timeMillis = 1000)
         }

--- a/srt/src/main/java/com/pedro/srt/srt/SrtSender.kt
+++ b/srt/src/main/java/com/pedro/srt/srt/SrtSender.kt
@@ -23,7 +23,6 @@ import com.pedro.common.BitrateManager
 import com.pedro.common.ConnectChecker
 import com.pedro.common.onMainThread
 import com.pedro.common.trySend
-import com.pedro.srt.mpeg2ts.Codec
 import com.pedro.srt.mpeg2ts.MpegTsPacket
 import com.pedro.srt.mpeg2ts.MpegTsPacketizer
 import com.pedro.srt.mpeg2ts.MpegType
@@ -57,241 +56,255 @@ import java.util.concurrent.TimeUnit
  * Created by pedro on 20/8/23.
  */
 class SrtSender(
-  private val connectChecker: ConnectChecker,
-  private val commandsManager: CommandsManager
+    private val connectChecker: ConnectChecker,
+    private val commandsManager: CommandsManager
 ) {
 
-  private val service = Mpeg2TsService()
+    private val service = Mpeg2TsService()
 
-  private val psiManager = PsiManager(service).apply {
-    upgradePatVersion()
-    upgradeSdtVersion()
-  }
-  private val limitSize = commandsManager.MTU - SrtPacket.headerSize
-  private val mpegTsPacketizer = MpegTsPacketizer(psiManager)
-  private var audioPacket: BasePacket = AacPacket(limitSize, psiManager)
-  private val h26XPacket = H26XPacket(limitSize, psiManager)
-
-  @Volatile
-  private var running = false
-  private var cacheSize = 200
-
-  private var job: Job? = null
-  private val scope = CoroutineScope(Dispatchers.IO)
-  @Volatile
-  private var queue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(cacheSize)
-  private var audioFramesSent: Long = 0
-  private var videoFramesSent: Long = 0
-  var socket: SrtSocket? = null
-  var droppedAudioFrames: Long = 0
-    private set
-  var droppedVideoFrames: Long = 0
-    private set
-
-  private val bitrateManager: BitrateManager = BitrateManager(connectChecker)
-  private var isEnableLogs = true
-
-  companion object {
-    private const val TAG = "SrtSender"
-  }
-
-  private fun setTrackConfig(videoEnabled: Boolean, audioEnabled: Boolean) {
-    Pid.reset()
-    service.clearTracks()
-    if (audioEnabled) service.addTrack(commandsManager.audioCodec.toCodec())
-    if (videoEnabled) service.addTrack(commandsManager.videoCodec.toCodec())
-    service.generatePmt()
-    psiManager.updateService(service)
-  }
-
-  fun setVideoInfo(sps: ByteBuffer, pps: ByteBuffer?, vps: ByteBuffer?) {
-    h26XPacket.setVideoCodec(commandsManager.videoCodec.toCodec())
-    h26XPacket.sendVideoInfo(sps, pps, vps)
-  }
-
-  fun setAudioInfo(sampleRate: Int, isStereo: Boolean) {
-    when (commandsManager.audioCodec) {
-      AudioCodec.AAC -> {
-        audioPacket = AacPacket(limitSize, psiManager)
-        (audioPacket as? AacPacket)?.sendAudioInfo(sampleRate, isStereo)
-      }
-      AudioCodec.OPUS -> {
-        audioPacket = OpusPacket(limitSize, psiManager)
-      }
-      AudioCodec.G711 -> {
-        throw IllegalArgumentException("Unsupported codec: ${commandsManager.audioCodec.name}")
-      }
+    private val psiManager = PsiManager(service).apply {
+        upgradePatVersion()
+        upgradeSdtVersion()
     }
-  }
+    private val limitSize = commandsManager.MTU - SrtPacket.headerSize
+    private val mpegTsPacketizer = MpegTsPacketizer(psiManager)
+    private var audioPacket: BasePacket = AacPacket(limitSize, psiManager)
+    private val h26XPacket = H26XPacket(limitSize, psiManager)
 
-  fun sendVideoFrame(h264Buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
-    if (running) {
-      h26XPacket.createAndSendPacket(h264Buffer, info) { mpegTsPackets ->
-        val isKey = mpegTsPackets[0].isKey
-        checkSendInfo(isKey)
-        val result = queue.trySend(mpegTsPackets)
-        if (!result) {
-          Log.i(TAG, "Video frame discarded")
-          droppedVideoFrames++
-        }
-      }
+    @Volatile
+    private var running = false
+    private var cacheSize = 200
+
+    private var job: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    @Volatile
+    private var queue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(cacheSize)
+    private var audioFramesSent: Long = 0
+    private var videoFramesSent: Long = 0
+    var socket: SrtSocket? = null
+    var droppedAudioFrames: Long = 0
+        private set
+    var droppedVideoFrames: Long = 0
+        private set
+
+    private val bitrateManager: BitrateManager = BitrateManager(connectChecker)
+    private var isEnableLogs = true
+
+    companion object {
+        private const val TAG = "SrtSender"
     }
-  }
 
-  fun sendAudioFrame(aacBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
-    if (running) {
-      audioPacket.createAndSendPacket(aacBuffer, info) { mpegTsPackets ->
-        val isKey = mpegTsPackets[0].isKey
-        checkSendInfo(isKey)
-        val result = queue.trySend(mpegTsPackets)
-        if (!result) {
-          Log.i(TAG, "Audio frame discarded")
-          droppedAudioFrames++
-        }
-      }
+    private fun setTrackConfig(videoEnabled: Boolean, audioEnabled: Boolean) {
+        Pid.reset()
+        service.clearTracks()
+        if (audioEnabled) service.addTrack(commandsManager.audioCodec.toCodec())
+        if (videoEnabled) service.addTrack(commandsManager.videoCodec.toCodec())
+        service.generatePmt()
+        psiManager.updateService(service)
     }
-  }
 
-  fun start() {
-    queue.clear()
-    setTrackConfig(!commandsManager.videoDisabled, !commandsManager.audioDisabled)
-    running = true
-    job = scope.launch {
-      //send config
-      val psiList = mutableListOf(psiManager.getSdt(), psiManager.getPat())
-      psiManager.getPmt()?.let { psiList.add(0, it) }
-      val psiPackets = mpegTsPacketizer.write(psiList).map { b ->
-        MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-      }
-      queue.trySend(psiPackets)
-      var bytesSend = 0L
-      val bitrateTask = async {
-        while (scope.isActive && running) {
-          //bytes to bits
-          bitrateManager.calculateBitrate(bytesSend * 8)
-          bytesSend = 0
-          delay(timeMillis = 1000)
-        }
-      }
-      while (scope.isActive && running) {
-        val error = runCatching {
-          val mpegTsPackets = runInterruptible {
-            queue.poll(1, TimeUnit.SECONDS)
-          }
-          mpegTsPackets.forEach { mpegTsPacket ->
-            var size = 0
-            size += commandsManager.writeData(mpegTsPacket, socket)
-            if (isEnableLogs) {
-              Log.i(TAG, "wrote ${mpegTsPacket.type.name} packet, size $size")
+    fun setVideoInfo(sps: ByteBuffer, pps: ByteBuffer?, vps: ByteBuffer?) {
+        h26XPacket.setVideoCodec(commandsManager.videoCodec.toCodec())
+        h26XPacket.sendVideoInfo(sps, pps, vps)
+    }
+
+    fun setAudioInfo(sampleRate: Int, isStereo: Boolean) {
+        when (commandsManager.audioCodec) {
+            AudioCodec.AAC -> {
+                audioPacket = AacPacket(limitSize, psiManager)
+                (audioPacket as? AacPacket)?.sendAudioInfo(sampleRate, isStereo)
             }
-            bytesSend += size
-          }
-        }.exceptionOrNull()
-        if (error != null) {
-          onMainThread {
-            connectChecker.onConnectionFailed("Error send packet, " + error.message)
-          }
-          Log.e(TAG, "send error: ", error)
-          return@launch
+
+            AudioCodec.OPUS -> {
+                audioPacket = OpusPacket(limitSize, psiManager)
+            }
+
+            AudioCodec.G711 -> {
+                throw IllegalArgumentException("Unsupported codec: ${commandsManager.audioCodec.name}")
+            }
         }
-      }
     }
-  }
 
-  private fun checkSendInfo(isKey: Boolean = false) {
-    val pmt = psiManager.getPmt() ?: return
-    when (psiManager.shouldSend(isKey)) {
-      TableToSend.PAT_PMT -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(psiManager.getPat(), pmt), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+    fun sendVideoFrame(h264Buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        if (running) {
+            h26XPacket.createAndSendPacket(h264Buffer, info) { mpegTsPackets ->
+                val isKey = mpegTsPackets[0].isKey
+                checkSendInfo(isKey)
+                val result = queue.trySend(mpegTsPackets)
+                if (!result) {
+                    Log.i(TAG, "Video frame discarded")
+                    droppedVideoFrames++
+                }
+            }
         }
-        queue.trySend(psiPackets)
-      }
-      TableToSend.SDT -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(psiManager.getSdt()), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-        }
-        queue.trySend(psiPackets)
-      }
-      TableToSend.NONE -> {}
-      TableToSend.ALL -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(pmt, psiManager.getSdt(), psiManager.getPat()), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-        }
-        queue.trySend(psiPackets)
-      }
     }
-  }
 
-  suspend fun stop(clear: Boolean) {
-    running = false
-    psiManager.reset()
-    service.clear()
-    mpegTsPacketizer.reset()
-    audioPacket.reset(clear)
-    h26XPacket.reset(clear)
-    resetSentAudioFrames()
-    resetSentVideoFrames()
-    resetDroppedAudioFrames()
-    resetDroppedVideoFrames()
-    job?.cancelAndJoin()
-    job = null
-    queue.clear()
-  }
-
-  @Throws(IllegalArgumentException::class)
-  fun hasCongestion(percentUsed: Float = 20f): Boolean {
-    if (percentUsed < 0 || percentUsed > 100) throw IllegalArgumentException("the value must be in range 0 to 100")
-    val size = queue.size.toFloat()
-    val remaining = queue.remainingCapacity().toFloat()
-    val capacity = size + remaining
-    return size >= capacity * (percentUsed / 100f)
-  }
-
-  fun resizeCache(newSize: Int) {
-    if (newSize < queue.size - queue.remainingCapacity()) {
-      throw RuntimeException("Can't fit current cache inside new cache size")
+    fun sendAudioFrame(aacBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        if (running) {
+            audioPacket.createAndSendPacket(aacBuffer, info) { mpegTsPackets ->
+                val isKey = mpegTsPackets[0].isKey
+                checkSendInfo(isKey)
+                val result = queue.trySend(mpegTsPackets)
+                if (!result) {
+                    Log.i(TAG, "Audio frame discarded")
+                    droppedAudioFrames++
+                }
+            }
+        }
     }
-    val tempQueue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(newSize)
-    queue.drainTo(tempQueue)
-    queue = tempQueue
-  }
 
-  fun getCacheSize(): Int {
-    return cacheSize
-  }
+    fun start() {
+        queue.clear()
+        setTrackConfig(!commandsManager.videoDisabled, !commandsManager.audioDisabled)
+        running = true
+        job = scope.launch {
+            //send config
+            val psiList = mutableListOf(psiManager.getSdt(), psiManager.getPat())
+            psiManager.getPmt()?.let { psiList.add(0, it) }
+            val psiPackets = mpegTsPacketizer.write(psiList).map { b ->
+                MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+            }
+            queue.trySend(psiPackets)
+            var bytesSend = 0L
+            val bitrateTask = async {
+                while (scope.isActive && running) {
+                    //bytes to bits
+                    bitrateManager.calculateBandwidth(bytesSend, 0)
+                    bytesSend = 0
+                    delay(timeMillis = 1000)
+                }
+            }
+            while (scope.isActive && running) {
+                val error = runCatching {
+                    val mpegTsPackets = runInterruptible {
+                        queue.poll(1, TimeUnit.SECONDS)
+                    }
+                    mpegTsPackets.forEach { mpegTsPacket ->
+                        var size = 0
+                        size += commandsManager.writeData(mpegTsPacket, socket)
+                        if (isEnableLogs) {
+                            Log.i(TAG, "wrote ${mpegTsPacket.type.name} packet, size $size")
+                        }
+                        bytesSend += size
+                    }
+                }.exceptionOrNull()
+                if (error != null) {
+                    onMainThread {
+                        connectChecker.onConnectionFailed("Error send packet, " + error.message)
+                    }
+                    Log.e(TAG, "send error: ", error)
+                    return@launch
+                }
+            }
+        }
+    }
 
-  fun getItemsInCache(): Int = queue.size
+    private fun checkSendInfo(isKey: Boolean = false) {
+        val pmt = psiManager.getPmt() ?: return
+        when (psiManager.shouldSend(isKey)) {
+            TableToSend.PAT_PMT -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(psiManager.getPat(), pmt),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
 
-  fun clearCache() {
-    queue.clear()
-  }
+            TableToSend.SDT -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(psiManager.getSdt()),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
 
-  fun getSentAudioFrames(): Long {
-    return audioFramesSent
-  }
+            TableToSend.NONE -> {}
+            TableToSend.ALL -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(pmt, psiManager.getSdt(), psiManager.getPat()),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
+        }
+    }
 
-  fun getSentVideoFrames(): Long {
-    return videoFramesSent
-  }
+    suspend fun stop(clear: Boolean) {
+        running = false
+        psiManager.reset()
+        service.clear()
+        mpegTsPacketizer.reset()
+        audioPacket.reset(clear)
+        h26XPacket.reset(clear)
+        resetSentAudioFrames()
+        resetSentVideoFrames()
+        resetDroppedAudioFrames()
+        resetDroppedVideoFrames()
+        job?.cancelAndJoin()
+        job = null
+        queue.clear()
+    }
 
-  fun resetSentAudioFrames() {
-    audioFramesSent = 0
-  }
+    @Throws(IllegalArgumentException::class)
+    fun hasCongestion(percentUsed: Float = 20f): Boolean {
+        if (percentUsed < 0 || percentUsed > 100) throw IllegalArgumentException("the value must be in range 0 to 100")
+        val size = queue.size.toFloat()
+        val remaining = queue.remainingCapacity().toFloat()
+        val capacity = size + remaining
+        return size >= capacity * (percentUsed / 100f)
+    }
 
-  fun resetSentVideoFrames() {
-    videoFramesSent = 0
-  }
+    fun resizeCache(newSize: Int) {
+        if (newSize < queue.size - queue.remainingCapacity()) {
+            throw RuntimeException("Can't fit current cache inside new cache size")
+        }
+        val tempQueue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(newSize)
+        queue.drainTo(tempQueue)
+        queue = tempQueue
+    }
 
-  fun resetDroppedAudioFrames() {
-    droppedAudioFrames = 0
-  }
+    fun getCacheSize(): Int {
+        return cacheSize
+    }
 
-  fun resetDroppedVideoFrames() {
-    droppedVideoFrames = 0
-  }
+    fun getItemsInCache(): Int = queue.size
 
-  fun setLogs(enable: Boolean) {
-    isEnableLogs = enable
-  }
+    fun clearCache() {
+        queue.clear()
+    }
+
+    fun getSentAudioFrames(): Long {
+        return audioFramesSent
+    }
+
+    fun getSentVideoFrames(): Long {
+        return videoFramesSent
+    }
+
+    fun resetSentAudioFrames() {
+        audioFramesSent = 0
+    }
+
+    fun resetSentVideoFrames() {
+        videoFramesSent = 0
+    }
+
+    fun resetDroppedAudioFrames() {
+        droppedAudioFrames = 0
+    }
+
+    fun resetDroppedVideoFrames() {
+        droppedVideoFrames = 0
+    }
+
+    fun setLogs(enable: Boolean) {
+        isEnableLogs = enable
+    }
 }

--- a/udp/src/main/java/com/pedro/udp/UdpSender.kt
+++ b/udp/src/main/java/com/pedro/udp/UdpSender.kt
@@ -56,241 +56,255 @@ import java.util.concurrent.TimeUnit
  * Created by pedro on 6/3/24.
  */
 class UdpSender(
-  private val connectChecker: ConnectChecker,
-  private val commandManager: CommandManager
+    private val connectChecker: ConnectChecker,
+    private val commandManager: CommandManager
 ) {
 
-  private val service = Mpeg2TsService()
+    private val service = Mpeg2TsService()
 
-  private val psiManager = PsiManager(service).apply {
-    upgradePatVersion()
-    upgradeSdtVersion()
-  }
-  private val limitSize = Constants.MTU
-  private val mpegTsPacketizer = MpegTsPacketizer(psiManager)
-  private var audioPacket: BasePacket = AacPacket(limitSize, psiManager)
-  private val h26XPacket = H26XPacket(limitSize, psiManager)
-
-  @Volatile
-  private var running = false
-  private var cacheSize = 200
-
-  private var job: Job? = null
-  private val scope = CoroutineScope(Dispatchers.IO)
-  @Volatile
-  private var queue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(cacheSize)
-  private var audioFramesSent: Long = 0
-  private var videoFramesSent: Long = 0
-  var socket: UdpSocket? = null
-  var droppedAudioFrames: Long = 0
-    private set
-  var droppedVideoFrames: Long = 0
-    private set
-
-  private val bitrateManager: BitrateManager = BitrateManager(connectChecker)
-  private var isEnableLogs = true
-
-  companion object {
-    private const val TAG = "SrtSender"
-  }
-
-  private fun setTrackConfig(videoEnabled: Boolean, audioEnabled: Boolean) {
-    Pid.reset()
-    service.clearTracks()
-    if (audioEnabled) service.addTrack(commandManager.audioCodec.toCodec())
-    if (videoEnabled) service.addTrack(commandManager.videoCodec.toCodec())
-    service.generatePmt()
-    psiManager.updateService(service)
-  }
-
-  fun setVideoInfo(sps: ByteBuffer, pps: ByteBuffer?, vps: ByteBuffer?) {
-    h26XPacket.setVideoCodec(commandManager.videoCodec.toCodec())
-    h26XPacket.sendVideoInfo(sps, pps, vps)
-  }
-
-  fun setAudioInfo(sampleRate: Int, isStereo: Boolean) {
-    when (commandManager.audioCodec) {
-      AudioCodec.AAC -> {
-        audioPacket = AacPacket(limitSize, psiManager)
-        (audioPacket as? AacPacket)?.sendAudioInfo(sampleRate, isStereo)
-      }
-      AudioCodec.OPUS -> {
-        audioPacket = OpusPacket(limitSize, psiManager)
-      }
-      AudioCodec.G711 -> {
-        throw IllegalArgumentException("Unsupported codec: ${commandManager.audioCodec.name}")
-      }
+    private val psiManager = PsiManager(service).apply {
+        upgradePatVersion()
+        upgradeSdtVersion()
     }
-  }
+    private val limitSize = Constants.MTU
+    private val mpegTsPacketizer = MpegTsPacketizer(psiManager)
+    private var audioPacket: BasePacket = AacPacket(limitSize, psiManager)
+    private val h26XPacket = H26XPacket(limitSize, psiManager)
 
-  fun sendVideoFrame(h264Buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
-    if (running) {
-      h26XPacket.createAndSendPacket(h264Buffer, info) { mpegTsPackets ->
-        val isKey = mpegTsPackets[0].isKey
-        checkSendInfo(isKey)
-        val result = queue.trySend(mpegTsPackets)
-        if (!result) {
-          Log.i(TAG, "Video frame discarded")
-          droppedVideoFrames++
-        }
-      }
+    @Volatile
+    private var running = false
+    private var cacheSize = 200
+
+    private var job: Job? = null
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    @Volatile
+    private var queue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(cacheSize)
+    private var audioFramesSent: Long = 0
+    private var videoFramesSent: Long = 0
+    var socket: UdpSocket? = null
+    var droppedAudioFrames: Long = 0
+        private set
+    var droppedVideoFrames: Long = 0
+        private set
+
+    private val bitrateManager: BitrateManager = BitrateManager(connectChecker)
+    private var isEnableLogs = true
+
+    companion object {
+        private const val TAG = "SrtSender"
     }
-  }
 
-  fun sendAudioFrame(aacBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
-    if (running) {
-      audioPacket.createAndSendPacket(aacBuffer, info) { mpegTsPackets ->
-        val isKey = mpegTsPackets[0].isKey
-        checkSendInfo(isKey)
-        val result = queue.trySend(mpegTsPackets)
-        if (!result) {
-          Log.i(TAG, "Audio frame discarded")
-          droppedAudioFrames++
-        }
-      }
+    private fun setTrackConfig(videoEnabled: Boolean, audioEnabled: Boolean) {
+        Pid.reset()
+        service.clearTracks()
+        if (audioEnabled) service.addTrack(commandManager.audioCodec.toCodec())
+        if (videoEnabled) service.addTrack(commandManager.videoCodec.toCodec())
+        service.generatePmt()
+        psiManager.updateService(service)
     }
-  }
 
-  fun start() {
-    queue.clear()
-    setTrackConfig(!commandManager.videoDisabled, !commandManager.audioDisabled)
-    running = true
-    job = scope.launch {
-      //send config
-      val psiList = mutableListOf(psiManager.getSdt(), psiManager.getPat())
-      psiManager.getPmt()?.let { psiList.add(0, it) }
-      val psiPackets = mpegTsPacketizer.write(psiList).map { b ->
-        MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-      }
-      queue.trySend(psiPackets)
-      var bytesSend = 0L
-      val bitrateTask = async {
-        while (scope.isActive && running) {
-          //bytes to bits
-          bitrateManager.calculateBitrate(bytesSend * 8)
-          bytesSend = 0
-          delay(timeMillis = 1000)
-        }
-      }
-      while (scope.isActive && running) {
-        val error = runCatching {
-          val mpegTsPackets = runInterruptible {
-            queue.poll(1, TimeUnit.SECONDS)
-          }
-          mpegTsPackets.forEach { mpegTsPacket ->
-            var size = 0
-            size += commandManager.writeData(mpegTsPacket, socket)
-            if (isEnableLogs) {
-              Log.i(TAG, "wrote ${mpegTsPacket.type.name} packet, size $size")
+    fun setVideoInfo(sps: ByteBuffer, pps: ByteBuffer?, vps: ByteBuffer?) {
+        h26XPacket.setVideoCodec(commandManager.videoCodec.toCodec())
+        h26XPacket.sendVideoInfo(sps, pps, vps)
+    }
+
+    fun setAudioInfo(sampleRate: Int, isStereo: Boolean) {
+        when (commandManager.audioCodec) {
+            AudioCodec.AAC -> {
+                audioPacket = AacPacket(limitSize, psiManager)
+                (audioPacket as? AacPacket)?.sendAudioInfo(sampleRate, isStereo)
             }
-            bytesSend += size
-          }
-        }.exceptionOrNull()
-        if (error != null) {
-          onMainThread {
-            connectChecker.onConnectionFailed("Error send packet, " + error.message)
-          }
-          Log.e(TAG, "send error: ", error)
-          return@launch
+
+            AudioCodec.OPUS -> {
+                audioPacket = OpusPacket(limitSize, psiManager)
+            }
+
+            AudioCodec.G711 -> {
+                throw IllegalArgumentException("Unsupported codec: ${commandManager.audioCodec.name}")
+            }
         }
-      }
     }
-  }
 
-  private fun checkSendInfo(isKey: Boolean = false) {
-    val pmt = psiManager.getPmt() ?: return
-    when (psiManager.shouldSend(isKey)) {
-      TableToSend.PAT_PMT -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(psiManager.getPat(), pmt), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+    fun sendVideoFrame(h264Buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        if (running) {
+            h26XPacket.createAndSendPacket(h264Buffer, info) { mpegTsPackets ->
+                val isKey = mpegTsPackets[0].isKey
+                checkSendInfo(isKey)
+                val result = queue.trySend(mpegTsPackets)
+                if (!result) {
+                    Log.i(TAG, "Video frame discarded")
+                    droppedVideoFrames++
+                }
+            }
         }
-        queue.trySend(psiPackets)
-      }
-      TableToSend.SDT -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(psiManager.getSdt()), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-        }
-        queue.trySend(psiPackets)
-      }
-      TableToSend.NONE -> {}
-      TableToSend.ALL -> {
-        val psiPackets = mpegTsPacketizer.write(listOf(pmt, psiManager.getSdt(), psiManager.getPat()), increasePsiContinuity = true).map { b ->
-          MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
-        }
-        queue.trySend(psiPackets)
-      }
     }
-  }
 
-  suspend fun stop(clear: Boolean) {
-    running = false
-    psiManager.reset()
-    service.clear()
-    mpegTsPacketizer.reset()
-    audioPacket.reset(clear)
-    h26XPacket.reset(clear)
-    resetSentAudioFrames()
-    resetSentVideoFrames()
-    resetDroppedAudioFrames()
-    resetDroppedVideoFrames()
-    job?.cancelAndJoin()
-    job = null
-    queue.clear()
-  }
-
-  @Throws(IllegalArgumentException::class)
-  fun hasCongestion(percentUsed: Float = 20f): Boolean {
-    if (percentUsed < 0 || percentUsed > 100) throw IllegalArgumentException("the value must be in range 0 to 100")
-    val size = queue.size.toFloat()
-    val remaining = queue.remainingCapacity().toFloat()
-    val capacity = size + remaining
-    return size >= capacity * (percentUsed / 100f)
-  }
-
-  fun resizeCache(newSize: Int) {
-    if (newSize < queue.size - queue.remainingCapacity()) {
-      throw RuntimeException("Can't fit current cache inside new cache size")
+    fun sendAudioFrame(aacBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        if (running) {
+            audioPacket.createAndSendPacket(aacBuffer, info) { mpegTsPackets ->
+                val isKey = mpegTsPackets[0].isKey
+                checkSendInfo(isKey)
+                val result = queue.trySend(mpegTsPackets)
+                if (!result) {
+                    Log.i(TAG, "Audio frame discarded")
+                    droppedAudioFrames++
+                }
+            }
+        }
     }
-    val tempQueue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(newSize)
-    queue.drainTo(tempQueue)
-    queue = tempQueue
-  }
 
-  fun getCacheSize(): Int {
-    return cacheSize
-  }
+    fun start() {
+        queue.clear()
+        setTrackConfig(!commandManager.videoDisabled, !commandManager.audioDisabled)
+        running = true
+        job = scope.launch {
+            //send config
+            val psiList = mutableListOf(psiManager.getSdt(), psiManager.getPat())
+            psiManager.getPmt()?.let { psiList.add(0, it) }
+            val psiPackets = mpegTsPacketizer.write(psiList).map { b ->
+                MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+            }
+            queue.trySend(psiPackets)
+            var bytesSend = 0L
+            val bitrateTask = async {
+                while (scope.isActive && running) {
+                    //bytes to bits
+                    bitrateManager.calculateBandwidth(bytesSend, 0)
+                    bytesSend = 0
+                    delay(timeMillis = 1000)
+                }
+            }
+            while (scope.isActive && running) {
+                val error = runCatching {
+                    val mpegTsPackets = runInterruptible {
+                        queue.poll(1, TimeUnit.SECONDS)
+                    }
+                    mpegTsPackets.forEach { mpegTsPacket ->
+                        var size = 0
+                        size += commandManager.writeData(mpegTsPacket, socket)
+                        if (isEnableLogs) {
+                            Log.i(TAG, "wrote ${mpegTsPacket.type.name} packet, size $size")
+                        }
+                        bytesSend += size
+                    }
+                }.exceptionOrNull()
+                if (error != null) {
+                    onMainThread {
+                        connectChecker.onConnectionFailed("Error send packet, " + error.message)
+                    }
+                    Log.e(TAG, "send error: ", error)
+                    return@launch
+                }
+            }
+        }
+    }
 
-  fun getItemsInCache(): Int = queue.size
+    private fun checkSendInfo(isKey: Boolean = false) {
+        val pmt = psiManager.getPmt() ?: return
+        when (psiManager.shouldSend(isKey)) {
+            TableToSend.PAT_PMT -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(psiManager.getPat(), pmt),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
 
-  fun clearCache() {
-    queue.clear()
-  }
+            TableToSend.SDT -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(psiManager.getSdt()),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
 
-  fun getSentAudioFrames(): Long {
-    return audioFramesSent
-  }
+            TableToSend.NONE -> {}
+            TableToSend.ALL -> {
+                val psiPackets = mpegTsPacketizer.write(
+                    listOf(pmt, psiManager.getSdt(), psiManager.getPat()),
+                    increasePsiContinuity = true
+                ).map { b ->
+                    MpegTsPacket(b, MpegType.PSI, PacketPosition.SINGLE, isKey = false)
+                }
+                queue.trySend(psiPackets)
+            }
+        }
+    }
 
-  fun getSentVideoFrames(): Long {
-    return videoFramesSent
-  }
+    suspend fun stop(clear: Boolean) {
+        running = false
+        psiManager.reset()
+        service.clear()
+        mpegTsPacketizer.reset()
+        audioPacket.reset(clear)
+        h26XPacket.reset(clear)
+        resetSentAudioFrames()
+        resetSentVideoFrames()
+        resetDroppedAudioFrames()
+        resetDroppedVideoFrames()
+        job?.cancelAndJoin()
+        job = null
+        queue.clear()
+    }
 
-  fun resetSentAudioFrames() {
-    audioFramesSent = 0
-  }
+    @Throws(IllegalArgumentException::class)
+    fun hasCongestion(percentUsed: Float = 20f): Boolean {
+        if (percentUsed < 0 || percentUsed > 100) throw IllegalArgumentException("the value must be in range 0 to 100")
+        val size = queue.size.toFloat()
+        val remaining = queue.remainingCapacity().toFloat()
+        val capacity = size + remaining
+        return size >= capacity * (percentUsed / 100f)
+    }
 
-  fun resetSentVideoFrames() {
-    videoFramesSent = 0
-  }
+    fun resizeCache(newSize: Int) {
+        if (newSize < queue.size - queue.remainingCapacity()) {
+            throw RuntimeException("Can't fit current cache inside new cache size")
+        }
+        val tempQueue: BlockingQueue<List<MpegTsPacket>> = LinkedBlockingQueue(newSize)
+        queue.drainTo(tempQueue)
+        queue = tempQueue
+    }
 
-  fun resetDroppedAudioFrames() {
-    droppedAudioFrames = 0
-  }
+    fun getCacheSize(): Int {
+        return cacheSize
+    }
 
-  fun resetDroppedVideoFrames() {
-    droppedVideoFrames = 0
-  }
+    fun getItemsInCache(): Int = queue.size
 
-  fun setLogs(enable: Boolean) {
-    isEnableLogs = enable
-  }
+    fun clearCache() {
+        queue.clear()
+    }
+
+    fun getSentAudioFrames(): Long {
+        return audioFramesSent
+    }
+
+    fun getSentVideoFrames(): Long {
+        return videoFramesSent
+    }
+
+    fun resetSentAudioFrames() {
+        audioFramesSent = 0
+    }
+
+    fun resetSentVideoFrames() {
+        videoFramesSent = 0
+    }
+
+    fun resetDroppedAudioFrames() {
+        droppedAudioFrames = 0
+    }
+
+    fun resetDroppedVideoFrames() {
+        droppedVideoFrames = 0
+    }
+
+    fun setLogs(enable: Boolean) {
+        isEnableLogs = enable
+    }
 }


### PR DESCRIPTION
Sideline app requires a very specific set of bandwidth notifications, which is based on what [HaishinKit.swift](https://github.com/shogo4405/HaishinKit.swift) provides: 

every second, we learn what the current throughput is, how many bytes are currently queued, and whether there have been 2 consecutive increases in the queued bytes (insufficient) , or where there have been no increases in the last 3 seconds (sufficient). 

