### PR TITLE
Update to allow publishing to dk-maven repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .gradle
 /local.properties
 /.idea
-/build
+build/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -171,3 +171,28 @@ https://github.com/pedroSG94/RootEncoder/tree/master/app/src/main/java/com/pedro
 
 Code example for low API devices (Android API 16+):
 https://github.com/pedroSG94/RootEncoder/tree/master/app/src/main/java/com/pedro/streamer/oldapi
+
+## DK Release and Deploy
+
+We use the [axion-release-plugin](https://axion-release-plugin.readthedocs.io/en/latest/) to help with versioning and releases.
+
+Basic workflow with axion-release:
+```
+$ ./gradlew currentVersion
+0.1.0
+
+$ git commit -m "Some commit."
+
+$ ./gradlew currentVersion
+0.1.1-SNAPSHOT
+
+// Create a new tag and push it to remote
+$ ./gradlew release
+
+$ git tag
+project-0.1.0
+project-0.1.1
+
+// Upload release to dk-maven
+$ ./gradlew publish
+```

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    compileOnly("com.android.tools.build:gradle:8.2.2")
+    implementation("software.amazon.awssdk:codeartifact:2.20.68")
+    implementation("pl.allegro.tech.build:axion-release-plugin:1.15.4")
+}
+
+gradlePlugin {
+    plugins {
+        register("projectVersioning") {
+            id = "convention.project.versioning"
+            implementationClass = "plugins.VersioningConventionPlugin"
+        }
+        register("projectPublishing") {
+            id = "convention.publishing"
+            implementationClass = "plugins.PublishingConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/extensions/PublishingConfigExtension.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/PublishingConfigExtension.kt
@@ -1,0 +1,30 @@
+package extensions
+
+open class PublishingConfigExtension(
+    var groupId: String = "",
+    var artifactId: String = "",
+    // CodeArtifact specific
+    var domain: String = "",
+    var domainOwner: String = "",
+    var repository: String = "",
+    var region: String = "us-east-1",
+) {
+    fun groupId(value: String) {
+        groupId = value
+    }
+    fun artifactId(value: String) {
+        artifactId = value
+    }
+    fun domain(value: String) {
+        domain = value
+    }
+    fun domainOwner(value: String) {
+        domainOwner = value
+    }
+    fun repository(value: String) {
+        repository = value
+    }
+    fun region(value: String) {
+        region = value
+    }
+}

--- a/build-logic/convention/src/main/kotlin/extensions/VersioningExtension.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/VersioningExtension.kt
@@ -1,0 +1,20 @@
+package extensions
+
+open class VersioningExtension(
+    var tagPrefix: String = "",
+    var useHighestVersion: Boolean = true,
+    var initialVersion: String = "0.1.0",
+) {
+
+    fun tagPrefix(value: String) {
+        tagPrefix = value
+    }
+
+    fun useHighestVersion(value: Boolean) {
+        useHighestVersion = value
+    }
+
+    fun initialVersion(value: String) {
+        initialVersion = value
+    }
+}

--- a/build-logic/convention/src/main/kotlin/plugins/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/PublishingConventionPlugin.kt
@@ -1,0 +1,75 @@
+package plugins
+
+import extensions.PublishingConfigExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
+
+@Suppress("unused")
+class PublishingConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("maven-publish")
+            }
+
+            val extension = extensions.create("publishingConfig", PublishingConfigExtension::class.java)
+
+            afterEvaluate {
+                configurePublishing(extension)
+            }
+        }
+    }
+
+    private fun Project.configurePublishing(extension: PublishingConfigExtension) {
+        extensions.configure<PublishingExtension> {
+            publications {
+                // Creates a Maven publication called "release".
+                create<MavenPublication>("release") {
+                    // Applies the component for the release build variant.
+                    from(components["release"])
+
+                    // You can then customize attributes of the publication as shown below.
+                    groupId = extension.groupId
+                    artifactId = extension.artifactId
+                }
+            }
+            repositories {
+                // CodeArtifact repository
+                maven {
+                    name = "CodeArtifact"
+                    url = project.uri(getCodeArtifactRepoUrl(extension))
+                    credentials {
+                        username = "aws"
+                        password = getCodeArtifactAuthToken(extension)
+                    }
+                }
+            }
+        }
+    }
+
+    @Suppress("ktlint:standard:max-line-length")
+    private fun getCodeArtifactRepoUrl(extension: PublishingConfigExtension): String {
+        return "https://${extension.domain}-${extension.domainOwner}.d.codeartifact.${extension.region}.amazonaws.com/maven/${extension.repository}/"
+    }
+
+    private fun getCodeArtifactAuthToken(extension: PublishingConfigExtension): String {
+        val client = CodeartifactClient.builder()
+            .region(Region.of(extension.region))
+            .build()
+
+        val request = GetAuthorizationTokenRequest.builder()
+            .domain(extension.domain)
+            .domainOwner(extension.domainOwner)
+            .build()
+
+        return client.getAuthorizationToken(request).authorizationToken()
+    }
+}

--- a/build-logic/convention/src/main/kotlin/plugins/VersioningConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/VersioningConventionPlugin.kt
@@ -1,0 +1,75 @@
+package plugins
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import extensions.VersioningExtension
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import pl.allegro.tech.build.axion.release.ReleasePlugin
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
+
+@Suppress("unused")
+class VersioningConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            if (this != rootProject) {
+                throw GradleException(
+                    "Versioning plugin can be applied to the root project only",
+                )
+            }
+
+            with(pluginManager) {
+                apply(ReleasePlugin::class.java)
+            }
+
+            val extension = extensions.create("versioning", VersioningExtension::class.java)
+
+            afterEvaluate {
+                configureVersioning(extension)
+            }
+        }
+    }
+
+    private fun Project.configureVersioning(extension: VersioningExtension) {
+        val scmConfig = extensions.getByType(VersionConfig::class.java).apply {
+            useHighestVersion.set(extension.useHighestVersion)
+            versionCreator("versionWithBranch")            
+            tag {
+                prefix.set(extension.tagPrefix)
+                versionSeparator.set("")
+                initialVersion.set({ _, _ -> extension.initialVersion })
+            }
+        }
+        allprojects {
+            version = scmConfig.version
+            setupAndroidVersioning(scmConfig)
+        }
+    }
+
+    private fun Project.setupAndroidVersioning(scmConfig: VersionConfig) {
+        val configureVersion: BaseExtension.(String) -> Unit = { version ->
+            val minor = version.split(".")[0].toInt()
+            val major = version.split(".")[1].toInt()
+            val patch = version.split(".")[2].toInt()
+            defaultConfig.versionCode = minor * MINOR_MULTIPLIER + major * MAJOR_MULTIPLIER + patch
+            defaultConfig.versionName = "$minor.$major.$patch"
+        }
+        pluginManager.withPlugin("com.android.library") {
+            extensions.getByType(LibraryExtension::class.java).apply {
+                configureVersion(scmConfig.undecoratedVersion)
+            }
+        }
+        pluginManager.withPlugin("com.android.application") {
+            extensions.getByType(AppExtension::class.java).apply {
+                configureVersion(scmConfig.undecoratedVersion)
+            }
+        }
+    }
+
+    companion object {
+        private const val MINOR_MULTIPLIER = 1_000_000
+        private const val MAJOR_MULTIPLIER = 1_000
+    }
+}

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,4 @@
+# Gradle properties are not passed to included builds https://github.com/gradle/gradle/issues/2534
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    @Suppress("UnstableApiUsage")
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-val libraryGroup by rootProject.extra { "com.github.pedroSG94" }
+val libraryGroup by rootProject.extra { "com.github.pedroSG94.RootEncoder" }
 val vCode by rootProject.extra { 240 }
 val vName by rootProject.extra { "2.4.0" }
 val coroutinesVersion by rootProject.extra { "1.7.3" }
@@ -10,6 +10,8 @@ plugins {
   id("com.android.application") version "8.2.2" apply false
   id("org.jetbrains.kotlin.android") version "1.9.23" apply false
   id("org.jetbrains.dokka") version "1.9.20" apply true
+
+  id("convention.project.versioning")
 }
 
 tasks.register("clean") {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("org.jetbrains.dokka")
+
+    id("convention.publishing")
 }
 
 android {
@@ -38,21 +40,13 @@ android {
     }
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            // Creates a Maven publication called "release".
-            create<MavenPublication>("release") {
-                // Applies the component for the release build variant.
-                from(components["release"])
-
-                // You can then customize attributes of the publication as shown below.
-                groupId = libraryGroup
-                artifactId = "common"
-                version = vName
-            }
-        }
-    }
+publishingConfig {
+    groupId = libraryGroup
+    artifactId = "common"
+    domain = "diamond-kinetics"
+    domainOwner = "626803233223"
+    repository = "dk-maven"
+    region = "us-east-1"
 }
 
 dependencies {

--- a/encoder/build.gradle.kts
+++ b/encoder/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
   id("maven-publish")
   id("org.jetbrains.dokka")
+
+  id("convention.publishing")
 }
 
 android {
@@ -35,21 +37,13 @@ android {
   }
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      create<MavenPublication>("release") {
-        // Applies the component for the release build variant.
-        from(components["release"])
-
-        // You can then customize attributes of the publication as shown below.
-        groupId = libraryGroup
-        artifactId = "encoder"
-        version = vName
-      }
-    }
-  }
+publishingConfig {
+  groupId = libraryGroup
+  artifactId = "encoder"
+  domain = "diamond-kinetics"
+  domainOwner = "626803233223"
+  repository = "dk-maven"
+  region = "us-east-1"
 }
 
 dependencies {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
   id("maven-publish")
   id("org.jetbrains.dokka")
+
+  id("convention.publishing")
 }
 
 android {
@@ -35,21 +37,13 @@ android {
   }
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      create<MavenPublication>("release") {
-        // Applies the component for the release build variant.
-        from(components["release"])
-
-        // You can then customize attributes of the publication as shown below.
-        groupId = libraryGroup
-        artifactId = "library"
-        version = vName
-      }
-    }
-  }
+publishingConfig {
+  groupId = libraryGroup
+  artifactId = "library"
+  domain = "diamond-kinetics"
+  domainOwner = "626803233223"
+  repository = "dk-maven"
+  region = "us-east-1"
 }
 
 dependencies {

--- a/rtmp/build.gradle.kts
+++ b/rtmp/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
   id("maven-publish")
   id("org.jetbrains.dokka")
+
+  id("convention.publishing")
 }
 
 android {
@@ -37,21 +39,13 @@ android {
   }
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      create<MavenPublication>("release") {
-        // Applies the component for the release build variant.
-        from(components["release"])
-
-        // You can then customize attributes of the publication as shown below.
-        groupId = libraryGroup
-        artifactId = "rtmp"
-        version = vName
-      }
-    }
-  }
+publishingConfig {
+  groupId = libraryGroup
+  artifactId = "rtmp"
+  domain = "diamond-kinetics"
+  domainOwner = "626803233223"
+  repository = "dk-maven"
+  region = "us-east-1"
 }
 
 dependencies {

--- a/rtsp/build.gradle.kts
+++ b/rtsp/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
   id("maven-publish")
   id("org.jetbrains.dokka")
+
+  id("convention.publishing")
 }
 
 android {
@@ -43,21 +45,13 @@ android {
   }
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      create<MavenPublication>("release") {
-        // Applies the component for the release build variant.
-        from(components["release"])
-
-        // You can then customize attributes of the publication as shown below.
-        groupId = libraryGroup
-        artifactId = "rtsp"
-        version = vName
-      }
-    }
-  }
+publishingConfig {
+  groupId = libraryGroup
+  artifactId = "rtsp"
+  domain = "diamond-kinetics"
+  domainOwner = "626803233223"
+  repository = "dk-maven"
+  region = "us-east-1"
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+  includeBuild("build-logic")
   repositories {
     google()
     mavenCentral()

--- a/srt/build.gradle.kts
+++ b/srt/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("org.jetbrains.dokka")
+
+    id("convention.publishing")
 }
 
 android {
@@ -37,21 +39,13 @@ android {
     }
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            // Creates a Maven publication called "release".
-            create<MavenPublication>("release") {
-                // Applies the component for the release build variant.
-                from(components["release"])
-
-                // You can then customize attributes of the publication as shown below.
-                groupId = libraryGroup
-                artifactId = "srt"
-                version = vName
-            }
-        }
-    }
+publishingConfig {
+    groupId = libraryGroup
+    artifactId = "srt"
+    domain = "diamond-kinetics"
+    domainOwner = "626803233223"
+    repository = "dk-maven"
+    region = "us-east-1"
 }
 
 dependencies {

--- a/udp/build.gradle.kts
+++ b/udp/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
   id("maven-publish")
   id("org.jetbrains.dokka")
+
+  id("convention.publishing")
 }
 
 android {
@@ -37,21 +39,13 @@ android {
   }
 }
 
-afterEvaluate {
-  publishing {
-    publications {
-      // Creates a Maven publication called "release".
-      create<MavenPublication>("release") {
-        // Applies the component for the release build variant.
-        from(components["release"])
-
-        // You can then customize attributes of the publication as shown below.
-        groupId = libraryGroup
-        artifactId = "udp"
-        version = vName
-      }
-    }
-  }
+publishingConfig {
+  groupId = libraryGroup
+  artifactId = "udp"
+  domain = "diamond-kinetics"
+  domainOwner = "626803233223"
+  repository = "dk-maven"
+  region = "us-east-1"
 }
 
 dependencies {


### PR DESCRIPTION
This adds the publishing and version plugins we use in other Android libraries. I tried to limit the changes so that if we ever needed to pull in updates from the upstream fork, we would reduce conflicts.

Once this is merged, I can publish this as version 2.4.0 to dk-maven.